### PR TITLE
Deployment bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ artifacts/*.tgz
 
 **/.coverage
 **/coverage.xml
+k8s/federated-node/Chart.lock
+k8s/federated-node/charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
     __Warning__ this will add and then remove the test data from keycloak and the db. It will not be enabled by default.
 
 ### bugfixes
-- Fixed an issue with first-time installations where on azure storage, the results folder should exist already. Now this is done by the backend initcontainer.
-- Fixed an issue where ingresses were not updated or deleted during upgrades
+- Fixed a deployment issue issue with first-time installations where on azure storage, the results folder should exist already. Now this is done by the backend's initcontainer.
+- Fixed a deployment issue where ingresses were not updated or deleted during upgrades
+- Fixed a deployment issue when using azure storage accounts, the secret containing auth credentials is missing on the tasks namespace. This led tasks to fail to start.
 
 ## 0.8.0
 - Added Container and Registry management:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
     ```
     __Warning__ this will add and then remove the test data from keycloak and the db. It will not be enabled by default.
 
+### bugfixes
+- Fixed an issue with first-time installations where on azure storage, the results folder should exist already. Now this is done by the backend initcontainer.
+- Fixed an issue where ingresses were not updated or deleted during upgrades
+
 ## 0.8.0
 - Added Container and Registry management:
     - /containers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a deployment issue issue with first-time installations where on azure storage, the results folder should exist already. Now this is done by the backend's initcontainer.
 - Fixed a deployment issue where ingresses were not updated or deleted during upgrades
 - Fixed a deployment issue when using azure storage accounts, the secret containing auth credentials is missing on the tasks namespace. This led tasks to fail to start.
+- Fixed a bug where tasks always have a fixed creation date, depending on server start. That caused some of them to be deemed expired.
 
 ## 0.8.0
 - Added Container and Registry management:

--- a/k8s/federated-node/templates/backend-deployment.yaml
+++ b/k8s/federated-node/templates/backend-deployment.yaml
@@ -76,16 +76,18 @@ spec:
             httpGet:
               path: /ready_check
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 180
+            initialDelaySeconds: 10
+            periodSeconds: 15
             timeoutSeconds: 30
+            failureThreshold: 5
           livenessProbe:
             httpGet:
               path: /health_check
               port: http
             initialDelaySeconds: 10
-            periodSeconds: 60
+            periodSeconds: 30
             timeoutSeconds: 30
+            failureThreshold: 5
           envFrom:
             - configMapRef:
                 name: backend-configmap

--- a/k8s/federated-node/templates/backend-deployment.yaml
+++ b/k8s/federated-node/templates/backend-deployment.yaml
@@ -124,4 +124,4 @@ spec:
       volumes:
         - name: respv
           persistentVolumeClaim:
-            claimName: flask-results-pv-volclaim
+            claimName: flask-results-pv-vc

--- a/k8s/federated-node/templates/backend-deployment.yaml
+++ b/k8s/federated-node/templates/backend-deployment.yaml
@@ -50,6 +50,15 @@ spec:
               secretKeyRef:
                 name: {{.Values.db.secret.name}}
                 key: {{.Values.db.secret.key}}
+        - name: storage-init
+          image: {{ include "fn-alpine" . }}
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - mkdir -p /mnt/storage/results
+          volumeMounts:
+            - name: respv
+              mountPath: /mnt/storage
       containers:
         - image: {{ template "backend-image" . }}:{{ .Values.backend.tag | default .Chart.AppVersion }}
           name: backend
@@ -109,6 +118,7 @@ spec:
           volumeMounts:
             - name: respv
               mountPath: {{ .Values.federatedNode.volumes.results_path }}
+              subPath: results
       volumes:
         - name: respv
           persistentVolumeClaim:

--- a/k8s/federated-node/templates/backend-results-pv.yaml
+++ b/k8s/federated-node/templates/backend-results-pv.yaml
@@ -23,7 +23,7 @@ spec:
           - linux
   {{ else if .Values.storage.azure }}
   azureFile:
-    shareName: {{ .Values.storage.azure.shareName }}/results
+    shareName: {{ .Values.storage.azure.shareName }}
     readOnly: false
     secretName: {{ .Values.storage.azure.secretName | default "azure-storage-secret" }}
   {{ else if .Values.storage.nfs }}

--- a/k8s/federated-node/templates/backend-results-pv.yaml
+++ b/k8s/federated-node/templates/backend-results-pv.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: results-pv
+  name: flask-results-pv
 spec:
   storageClassName: shared-results
   accessModes:
@@ -32,11 +32,11 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: flask-results-pv-volclaim
+  name: flask-results-pv-vc
   namespace: {{ .Release.namespace }}
 spec:
   storageClassName: shared-results
-  volumeName: results-pv
+  volumeName: flask-results-pv
   resources:
     requests:
       storage: 100Mi

--- a/k8s/federated-node/templates/copy-sercets.yaml
+++ b/k8s/federated-node/templates/copy-sercets.yaml
@@ -14,3 +14,17 @@ data:
 type: {{ $sec.type}}
 ---
 {{- end }}
+{{- if .Values.storage.azure }}
+{{ $sec := lookup "v1" "Secret" $.Release.Namespace .Values.storage.azure.secretName | default dict }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.storage.azure.secretName }}
+  namespace: {{ .Values.namespaces.tasks }}
+data:
+{{- with $sec.data  }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+type: {{ $sec.type}}
+---
+{{- end }}

--- a/k8s/federated-node/templates/nginx-deployment.1.10.0.yaml
+++ b/k8s/federated-node/templates/nginx-deployment.1.10.0.yaml
@@ -340,6 +340,7 @@ metadata:
     app.kubernetes.io/version: "1.10.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/component: controller
+    rollme: {{ template "rollMe" . }}
   name: ingress-nginx-controller
   namespace: {{ .Values.namespaces.nginx }}
 spec:

--- a/k8s/federated-node/templates/nginx-deployment.1.10.0.yaml
+++ b/k8s/federated-node/templates/nginx-deployment.1.10.0.yaml
@@ -385,6 +385,9 @@ spec:
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
             - --enable-metrics=false
+            {{- if .Values.ingress.tls }}
+            - --default-ssl-certificate={{ .Release.Namespace }}/{{ .Values.ingress.tls.secretName | default "tls" }}
+            {{- end }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 101

--- a/k8s/federated-node/templates/nginx-ingress.yaml
+++ b/k8s/federated-node/templates/nginx-ingress.yaml
@@ -21,7 +21,7 @@ spec:
   - hosts:
     - {{ .Values.ingress.host }}
     {{ if .Values.ingress.tls }}
-    secretName: {{ .Values.ingress.tls.secretName | default "tls"}}
+    secretName: {{ .Values.ingress.tls.secretName | default "tls" }}
     {{ end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/k8s/federated-node/templates/nginx-ingress.yaml
+++ b/k8s/federated-node/templates/nginx-ingress.yaml
@@ -2,7 +2,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: federated-ingress
+  labels:
+    {{ include "defaultLabels" . }}
   annotations:
+    {{ include "defaultAnnotations" . }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- if .Values.ingress.whitelist.enabled }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ join "," .Values.ingress.whitelist.ips | quote }}
@@ -10,7 +13,7 @@ metadata:
     {{- if .Values.ingress.blacklist.enabled }}
     nginx.ingress.kubernetes.io/denylist-source-range: {{ join "," .Values.ingress.blacklist.ips | quote }}
     {{- end }}
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   ingressClassName: {{ .Values.ingress.ingressClass | default "fn-nginx" }}
@@ -46,6 +49,7 @@ metadata:
     nginx.ingress.kubernetes.io/denylist-source-range: {{ join "," .Values.ingress.blacklist.ips | quote }}
     {{- end }}
     helm.sh/hook-weight: "5"
+    rollme: {{ template "rollMe" . }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClass | default "fn-nginx" }}
   tls:

--- a/k8s/federated-node/templates/result-cleaner-cronjob.yaml
+++ b/k8s/federated-node/templates/result-cleaner-cronjob.yaml
@@ -63,4 +63,4 @@ spec:
           volumes:
           - name: respv
             persistentVolumeClaim:
-              claimName: flask-results-pv-volclaim
+              claimName: flask-results-pv-vc

--- a/webserver/Makefile
+++ b/webserver/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
-VERSION=0.0.1
+VERSION=0.8.0
 
 env:
 	set -o allexport && source dev.env && set +o allexport

--- a/webserver/app/models/task.py
+++ b/webserver/app/models/task.py
@@ -48,7 +48,6 @@ class Task(db.Model, BaseModel):
                  inputs:dict = {},
                  outputs:dict = {},
                  description:str = '',
-                 created_at:datetime=datetime.now(),
                  **kwargs
                  ):
         self.name = name
@@ -57,7 +56,7 @@ class Task(db.Model, BaseModel):
         self.requested_by = requested_by
         self.dataset = dataset
         self.description = description
-        self.created_at = created_at
+        self.created_at = datetime.now()
         self.updated_at = datetime.now()
         self.tags = tags
         self.executors = executors

--- a/webserver/tests/test_tasks.py
+++ b/webserver/tests/test_tasks.py
@@ -581,10 +581,10 @@ class TestTaskResults:
             docker_image="image:tag",
             description="something",
             requested_by="abc123-412-51251-213-412",
-            dataset=dataset,
-            created_at=datetime.now() - timedelta(days=CLEANUP_AFTER_DAYS)
+            dataset=dataset
         )
         task.add()
+        task.created_at=datetime.now() - timedelta(days=CLEANUP_AFTER_DAYS)
         response = client.get(
             f'/tasks/{task.id}/results',
             headers=simple_admin_header


### PR DESCRIPTION
- Fixed a deployment issue issue with first-time installations where on azure storage, the results folder should exist already. Now this is done by the backend's initcontainer.
- Fixed a deployment issue where ingresses were not updated or deleted during upgrades
- Fixed a deployment issue when using azure storage accounts, the secret containing auth credentials is missing on the tasks namespace. This led tasks to fail to start.