### PR TITLE
Kyecloak credential refresher job fails too quick

### DIFF
--- a/build/kc-init/Dockerfile
+++ b/build/kc-init/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update \
 COPY *.py /scripts/
 
 USER ${USER_UID}
-ENTRYPOINT [ "/bin/sh", "-c", "python3 /scripts/init_credentials.py" ]
+ENTRYPOINT [ "/bin/sh", "-c", "python3 /scripts/refresh_credentials.py" ]

--- a/build/kc-init/common.py
+++ b/build/kc-init/common.py
@@ -1,0 +1,51 @@
+import requests
+import time
+
+
+MAX_RETRIES = 20
+
+
+def health_check(kc_url:str):
+    """
+    Simple kecyloak health check
+    """
+    print("Health check on keycloak pod before starting")
+    for i in range(1, MAX_RETRIES):
+        print(f"Health check {i}/{MAX_RETRIES}")
+        try:
+            hc_resp = requests.get(f"{kc_url}/realms/master")
+            if hc_resp.ok:
+                print("Keycloak is alive")
+                break
+        except requests.exceptions.ConnectionError:
+            pass
+        print("Health check failed...retrying in 10 seconds")
+        time.sleep(10)
+
+    if i == MAX_RETRIES:
+        print("Keycloak cannot be reached")
+        exit(1)
+
+def login(kc_url:str, kc_pass:str) -> str:
+    """
+    Common login function, gets the url and the password as the user is always the same.
+    Returns the access_token
+    """
+    print("Logging in...")
+    url = f"{kc_url}/realms/master/protocol/openid-connect/token"
+    headers = {
+        'Content-Type': 'application/x-www-form-urlencoded'
+    }
+
+    response = requests.post(url, headers=headers, data={
+        'client_id': 'admin-cli',
+        'grant_type': 'password',
+        'username': 'admin',
+        'password': kc_pass
+    })
+    if not response.ok:
+        print(response.json())
+        exit(1)
+
+    print("Successful")
+    return response.json()["access_token"]

--- a/build/kc-init/setup_realm.py
+++ b/build/kc-init/setup_realm.py
@@ -16,15 +16,18 @@ KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "FederatedNode")
 KEYCLOAK_CLIENT = os.getenv("KEYCLOAK_CLIENT", "global")
 KEYCLOAK_USER = os.getenv("KEYCLOAK_ADMIN")
 KEYCLOAK_PASS = os.getenv("KEYCLOAK_ADMIN_PASSWORD")
+MAX_RETRIES = 20
+
 
 def is_response_good(response:Response) -> None:
   if not response.ok and response.status_code != 409:
     print(f"{response.status_code} - {response.text}")
     exit(1)
 
+
 print("Health check on keycloak pod before starting")
-for i in range(1, 5):
-    print(f"Health check {i}/5")
+for i in range(1, MAX_RETRIES):
+    print(f"Health check {i}/{MAX_RETRIES}")
     try:
       hc_resp = requests.get(f"{KEYCLOAK_URL}/realms/master")
       if hc_resp.ok:
@@ -33,7 +36,8 @@ for i in range(1, 5):
         pass
     print("Health check failed...retrying in 10 seconds")
     time.sleep(10)
-if i == 5:
+
+if i == MAX_RETRIES:
     print("Keycloak cannot be reached")
     exit(1)
 

--- a/build/kc-init/setup_realm.py
+++ b/build/kc-init/setup_realm.py
@@ -7,7 +7,7 @@ import requests
 from requests import Response
 import json
 import os
-import time
+from common import login, health_check
 
 KEYCLOAK_NAMESPACE = os.getenv("KEYCLOAK_NAMESPACE")
 KEYCLOAK_URL = os.getenv("KEYCLOAK_URL", f"http://keycloak.{KEYCLOAK_NAMESPACE}.svc.cluster.local")
@@ -16,7 +16,6 @@ KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "FederatedNode")
 KEYCLOAK_CLIENT = os.getenv("KEYCLOAK_CLIENT", "global")
 KEYCLOAK_USER = os.getenv("KEYCLOAK_ADMIN")
 KEYCLOAK_PASS = os.getenv("KEYCLOAK_ADMIN_PASSWORD")
-MAX_RETRIES = 20
 
 
 def is_response_good(response:Response) -> None:
@@ -25,41 +24,11 @@ def is_response_good(response:Response) -> None:
     exit(1)
 
 
-print("Health check on keycloak pod before starting")
-for i in range(1, MAX_RETRIES):
-    print(f"Health check {i}/{MAX_RETRIES}")
-    try:
-      hc_resp = requests.get(f"{KEYCLOAK_URL}/realms/master")
-      if hc_resp.ok:
-          break
-    except requests.exceptions.ConnectionError:
-        pass
-    print("Health check failed...retrying in 10 seconds")
-    time.sleep(10)
-
-if i == MAX_RETRIES:
-    print("Keycloak cannot be reached")
-    exit(1)
+health_check(KEYCLOAK_URL)
 
 print(f"Accessing to keycloak {REALM} realm")
 
-payload = {
-    'client_id': 'admin-cli',
-    'grant_type': 'password',
-    'username': KEYCLOAK_USER,
-    'password': KEYCLOAK_PASS
-}
-headers = {
-  'Content-Type': 'application/x-www-form-urlencoded'
-}
-
-response = requests.post(
-    f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token",
-    headers=headers,
-    data=payload
-)
-is_response_good(response)
-admin_token = response.json()["access_token"]
+admin_token = login(KEYCLOAK_URL, KEYCLOAK_PASS)
 
 print("Got the token...Creating user in new Realm")
 payload = json.dumps({

--- a/k8s/federated-node/templates/keycloak-realm-job.yaml
+++ b/k8s/federated-node/templates/keycloak-realm-job.yaml
@@ -16,6 +16,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
+          imagePullPolicy: {{ .Values.pullPolicy }}
           image: "ghcr.io/aridhia-open-source/keycloak_initializer:{{ .Values.keycloak.tag | default .Chart.AppVersion }}"
           command: ["/bin/sh", "-c", "python3 /scripts/setup_realm.py" ]
           {{ include "nonRootSC" . }}

--- a/k8s/federated-node/templates/keycloak-secret-refresher-job.yaml
+++ b/k8s/federated-node/templates/keycloak-secret-refresher-job.yaml
@@ -20,7 +20,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: pre-kc-install-job
-          image: "ghcr.io/aridhia-open-source/keycloak_initializer:{{ .Values.keycloak.tag | default .Chart.AppVersion }}"
+          image: "ghcr.io/aridhia-open-source/keycloak_initializer:0.9.0-test"
+          imagePullPolicy: {{ .Values.pullPolicy }}
           {{ include "nonRootSC" . }}
           env:
             - name: KEYCLOAK_NAMESPACE

--- a/k8s/federated-node/templates/keycloak-secret-refresher-job.yaml
+++ b/k8s/federated-node/templates/keycloak-secret-refresher-job.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: keycloak-secrets-init
+  name: keycloak-secrets-refresh
   namespace: {{ .Values.namespaces.keycloak }}
   annotations:
     helm.sh/hook: pre-upgrade

--- a/k8s/federated-node/templates/keycloak-secret-refresher-job.yaml
+++ b/k8s/federated-node/templates/keycloak-secret-refresher-job.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: pre-kc-install-job
-          image: "ghcr.io/aridhia-open-source/keycloak_initializer:0.9.0-test"
+          image: "ghcr.io/aridhia-open-source/keycloak_initializer:{{ .Values.keycloak.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           {{ include "nonRootSC" . }}
           env:

--- a/k8s/federated-node/templates/keycloak-statefulset.yaml
+++ b/k8s/federated-node/templates/keycloak-statefulset.yaml
@@ -49,6 +49,12 @@ spec:
               port: 8080
             initialDelaySeconds: 20
             periodSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /realms/master
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 30
           env:
             - name: KC_DB_PASSWORD
               valueFrom:

--- a/k8s/federated-node/templates/keycloak-statefulset.yaml
+++ b/k8s/federated-node/templates/keycloak-statefulset.yaml
@@ -49,12 +49,6 @@ spec:
               port: 8080
             initialDelaySeconds: 20
             periodSeconds: 30
-          livenessProbe:
-            httpGet:
-              path: /realms/master
-              port: 8080
-            initialDelaySeconds: 20
-            periodSeconds: 30
           env:
             - name: KC_DB_PASSWORD
               valueFrom:

--- a/webserver/docker-compose-tests-ci.yaml
+++ b/webserver/docker-compose-tests-ci.yaml
@@ -57,6 +57,7 @@ services:
       KEYCLOAK_URL:
     volumes:
       - ../build/kc-init/setup_realm.py:/scripts/setup_realm.py
+      - ../build/kc-init/common.py:/scripts/common.py
   app:
     container_name: flask_app_test
     image: federated_node_app_test


### PR DESCRIPTION
Renamed some templates to be clearer on what they do. Same for the init jobs scripts.
Added health checks for the secret refresher. 
Increased tries for kc jobs pinging the service to 20