### PR TITLE
Certmanager

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,9 @@ jobs:
           echo "Setting version according to the Chart.yaml"
           cd k8s/federated-node
 
-          version=$(grep 'version:.*' Chart.yaml | sed 's/^.*: //')
+          version=$(grep '^version:.*' Chart.yaml | sed 's/^.*: //')
           echo "Chart version: ${version}"
-          appVersion=$(grep 'appVersion:.*' Chart.yaml | sed 's/^.*: \"//'| sed 's/\"//')
+          appVersion=$(grep '^appVersion:.*' Chart.yaml | sed 's/^.*: \"//'| sed 's/\"//')
           echo "Chart appVersion: ${appVersion}"
 
           if [[ "${{ env.DEV_BUILD }}" == "false" ]]; then
@@ -197,3 +197,4 @@ jobs:
       PATH_BUILD: k8s/federated-node
       CHART_NAME: federated-node
       IS_TAG: ${{ needs.init.outputs.is_tag }}
+      HAS_SUBCHART: true

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -66,7 +66,7 @@ jobs:
           fi
           cat Chart.yaml
       - name: Commit Changes
-        if: !inputs.dryRun
+        if: ${{ ! inputs.dryRun }}
         run: |
           git config user.email "phemsbot@phems.com"
           git config user.name "PHEMS bot"

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-      - name: Update Version
+      - name: Update Chart Version
         working-directory: k8s/federated-node
         env:
           CHART_VERSION: ${{ inputs.chartVersion }}
@@ -55,16 +55,22 @@ jobs:
           if [[ -n "${APP_VERSION}" ]]; then
             sed -i "s/appVersion: .*/appVersion: \"${APP_VERSION}\"/" Chart.yaml
           fi
+          cat Chart.yaml
+      - name: Update SubCharts Version
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CERTMANAGER_VERSION: ${{ inputs.certManager }}
+        run: |
           if [[ -n "${CERTMANAGER_VERSION}" ]]; then
             python ../../scripts/upgrade_subchart.py -s cert-manager -v ${CERTMANAGER_VERSION}
           fi
           cat Chart.yaml
+      - name: Commit Changes
+        if: !inputs.dryRun
+        run: |
+          git config user.email "phemsbot@phems.com"
+          git config user.name "PHEMS bot"
 
-          if [[ "${{ inputs.dryRun }}" == "false" ]]; then
-            git config user.email "phemsbot@phems.com"
-            git config user.name "PHEMS bot"
-
-            git add Chart.yaml
-            git commit -m "Version bump to ${CHART_VERSION}"
-            git push
-          fi
+          git add Chart.yaml
+          git commit -m "Version bump to ${CHART_VERSION}"
+          git push

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -64,9 +64,10 @@ jobs:
           if [[ -n "${CERTMANAGER_VERSION}" ]]; then
             python scripts/upgrade_subchart.py -s cert-manager -v ${CERTMANAGER_VERSION}
           fi
-          cat Chart.yaml
+          cat k8s/federated-node/Chart.yaml
       - name: Commit Changes
         if: ${{ ! inputs.dryRun }}
+        working-directory: k8s/federated-node
         run: |
           git config user.email "phemsbot@phems.com"
           git config user.name "PHEMS bot"

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -62,7 +62,7 @@ jobs:
           CERTMANAGER_VERSION: ${{ inputs.certManager }}
         run: |
           if [[ -n "${CERTMANAGER_VERSION}" ]]; then
-            python ../../scripts/upgrade_subchart.py -s cert-manager -v ${CERTMANAGER_VERSION}
+            python scripts/upgrade_subchart.py -s cert-manager -v ${CERTMANAGER_VERSION}
           fi
           cat Chart.yaml
       - name: Commit Changes

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: true
+      certManager:
+        description: 'CertManager sub-chart version'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -40,6 +44,7 @@ jobs:
           CHART_VERSION: ${{ inputs.chartVersion }}
           APP_VERSION: ${{ inputs.appVersion }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CERTMANAGER_VERSION: ${{ inputs.certManager }}
         run: |
           if [[ $(grep '${CHART_VERSION}' Chart.yaml) ]]; then
             echo "Nothing to change. Exiting early"
@@ -50,7 +55,9 @@ jobs:
           if [[ -n "${APP_VERSION}" ]]; then
             sed -i "s/appVersion: .*/appVersion: \"${APP_VERSION}\"/" Chart.yaml
           fi
-
+          if [[ -n "${CERTMANAGER_VERSION}" ]]; then
+            python ../../scripts/upgrade_subchart.py -s cert-manager -v ${CERTMANAGER_VERSION}
+          fi
           cat Chart.yaml
 
           if [[ "${{ inputs.dryRun }}" == "false" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ artifacts/*.tgz
 
 **/.coverage
 **/coverage.xml
+k8s/federated-node/Chart.lock
+k8s/federated-node/charts/*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Releases Changelog
 
 ## 0.10.0
-- Added `certmanager` to handle SSL renewal. Set `certmanager.enabled` in the values file to `true`.
+- Added `cert-manager` to handle SSL renewal. Set `cert-manager.enabled` in the values file to `true`.
 
 ## 0.9.0
 - Added a test suite for the helm chart. This can be simply run with `helm test federatednode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Releases Changelog
 
+## 0.10.0
+- Added `certmanager` to handle SSL renewal. Set `certmanager.enabled` in the values file to `true`.
+
 ## 0.9.0
 - Added a test suite for the helm chart. This can be simply run with `helm test federatednode`
 - __smoketests__ can be also run if the values file contains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## 0.10.0
 - Added `cert-manager` to handle SSL renewal. Set `cert-manager.enabled` in the values file to `true`.
 
+    An example of configuration on AKS would be:
+    ```yaml
+    cert-manager:
+        enabled: true
+    certs:
+        azure:
+            configmap: azuredns-config
+            secretName: azuredns-secret
+    ```
+    If not needed leave `cert-manager` and `certs` out of the values file.
+
 ## 0.9.0
 - Added a test suite for the helm chart. This can be simply run with `helm test federatednode`
 - __smoketests__ can be also run if the values file contains

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -97,14 +97,10 @@ The `cert-manager` tool will be used to provide this functionality. It is disabl
 
 If used, it will need few information based on which cloud platform it needs to interface with.
 
-Either way, a secret
 ##### Azure
 ```sh
 kubectl create secret generic $secret_name \
-    --from-literal=RG_NAME="$rg_name" git \
-    --from-literal=CLIENT_ID="$client_id" \
-    --from-literal=EMAIL_CERT="$email_cert" \
-    --from-literal=SUBSCRIPTION_ID="$sub_id"
+    --from-literal=CLIENT_SECRET="$SP_SECRET"
 ```
 or using the yaml template:
 ```yaml
@@ -117,17 +113,44 @@ metadata:
     # Otherwise you can set to default, or not use the next field altogether
     namespace:
 data:
-  DNS_SP_ID:
-  DNS_SP_SECRET:
-  AZ_DIRECTORY_ID:
-  SUBSCRIPTION_ID:
+  CLIENT_SECRET:
 type: Opaque
+```
+In addition, a ConfigMap is needed with the less sensitive data:
+```sh
+kubectl create configmap $configmap \
+    --from-literal=CLIENT_ID="$CLIENT_ID" \
+    --from-literal=EMAIL_CERT="$EMAIL_CERT" \
+    --from-literal=HOSTED_ZONE="$HOSTED_ZONE" \
+    --from-literal=RG_NAME="$RG_NAME" \
+    --from-literal=SUBSCRIPTION_ID="$SUB_ID" \
+    --from-literal=TENANT_ID="$TENANT_ID"
+```
+or using the yaml template:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    # set a name of your choosing
+    name:
+    # use the namespace name in case you plan to deploy in a non-default one.
+    # Otherwise you can set to default, or not use the next field altogether
+    namespace:
+data:
+  CLIENT_ID:
+  EMAIL_CERT:
+  HOSTED_ZONE:
+  RG_NAME:
+  SUBSCRIPTION_ID:
+  TENANT_ID:
 ```
 ##### AWS:
 ```sh
 kubectl create secret generic $secret_name \
-    --from-literal=AWS_ACCESS_KEY_ID="$key_id" \
-    --from-literal=AWS_SECRET_ACCESS_KEY="$key_secret"
+    --from-literal=EMAIL_CERT="$EMAIL_CERT" \
+    --from-literal=ACCOUNT_ID="$ACCOUNT_ID" \
+    --from-literal=REGION="$REGION" \
+    --from-literal=ROLE_NAME="$ROLE_NAME"
 ```
 or using the yaml template:
 ```yaml
@@ -140,8 +163,10 @@ metadata:
     # Otherwise you can set to default, or not use the next field altogether
     namespace:
 data:
-  AWS_ACCESS_KEY_ID:
-  AWS_SECRET_ACCESS_KEY:
+  EMAIL_CERT:
+  ACCOUNT_ID:
+  REGION:
+  ROLE_NAME:
 type: Opaque
 ```
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,37 +37,6 @@ __Please keep in mind that every secret value has to be a base64 encoded string 
 echo -n "value" | base64
 ```
 
-#### Container Registries
-The following examples aims to setup container registries (CRs) credentials. The assumption is that all container registries are private, not public. That is because is expected that all the code to be run in the datasets has to be vetted, supervised by the data controllers.
-
-In general, to create a k8s secret you run a command like the following:
-```sh
-kubectl create secret generic $secret_name \
-    --from-literal=username="$username" \
-    --from-literal=password="$password"
-```
-or using the yaml template:
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-    # set a name of your choosing
-    name:
-    # use the namespace name in case you plan to deploy in a non-default one.
-    # Otherwise you can set to default, or not use the next field altogether
-    namespace:
-data:
-  password:
-  username:
-type: Opaque
-```
-
-then you can apply this secret with the command:
-```sh
-kubectl apply -f file.yaml
-```
-replace file.yaml with the name of the file you created above.
-
 #### Database
 In case you want to set DB secrets the structure is slightly different:
 
@@ -122,6 +91,59 @@ Granted that the `pem` and `crt` file already in the current working folder, run
 kubectl create secret tls tls --key key.pem --cert cert.crt
 ```
 This will create a special kubernetes secret in the default namespace, append `-n namespace_name` to create it in a specific namespace (i.e. the one where the chart is going to be deployed on)
+
+##### Automatic certificate renewal
+The `cert-manager` tool will be used to provide this functionality. It is disabled by default, if it's needed, set `certmanager.enabled` to `true` in your values file at deployment time.
+
+If used, it will need few information based on which cloud platform it needs to interface with.
+
+Either way, a secret
+##### Azure
+```sh
+kubectl create secret generic $secret_name \
+    --from-literal=RG_NAME="$rg_name" git \
+    --from-literal=CLIENT_ID="$client_id" \
+    --from-literal=EMAIL_CERT="$email_cert" \
+    --from-literal=SUBSCRIPTION_ID="$sub_id"
+```
+or using the yaml template:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    # set a name of your choosing
+    name:
+    # use the namespace name in case you plan to deploy in a non-default one.
+    # Otherwise you can set to default, or not use the next field altogether
+    namespace:
+data:
+  DNS_SP_ID:
+  DNS_SP_SECRET:
+  AZ_DIRECTORY_ID:
+  SUBSCRIPTION_ID:
+type: Opaque
+```
+##### AWS:
+```sh
+kubectl create secret generic $secret_name \
+    --from-literal=AWS_ACCESS_KEY_ID="$key_id" \
+    --from-literal=AWS_SECRET_ACCESS_KEY="$key_secret"
+```
+or using the yaml template:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    # set a name of your choosing
+    name:
+    # use the namespace name in case you plan to deploy in a non-default one.
+    # Otherwise you can set to default, or not use the next field altogether
+    namespace:
+data:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+type: Opaque
+```
 
 ### Copying existing secrets
 If the secret(s) exist in another namespace, you can "copy" them with this command:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -93,12 +93,12 @@ kubectl create secret tls tls --key key.pem --cert cert.crt
 This will create a special kubernetes secret in the default namespace, append `-n namespace_name` to create it in a specific namespace (i.e. the one where the chart is going to be deployed on)
 
 ##### Automatic certificate renewal
-The `cert-manager` tool will be used to provide this functionality. It is disabled by default, if it's needed, set `certmanager.enabled` to `true` in your values file at deployment time.
+The `cert-manager` tool will be used to provide this functionality. It is disabled by default, if it's needed, set `cert-manager.enabled` to `true` in your values file at deployment time.
 
 If used, it will need few information based on which cloud platform it needs to interface with.
 
 ##### Azure
-For azure dns issued certificates, the service principle approach is used. `certmanager` [documentation](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#service-principal) explains what is needed.
+For azure dns issued certificates, the service principle approach is used. `cert manager` [documentation](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#service-principal) explains what is needed.
 ```sh
 kubectl create secret generic $secret_name \
     --from-literal=SP_SECRET="$SP_SECRET"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -98,9 +98,10 @@ The `cert-manager` tool will be used to provide this functionality. It is disabl
 If used, it will need few information based on which cloud platform it needs to interface with.
 
 ##### Azure
+For azure dns issued certificates, the service principle approach is used. `certmanager` [documentation](https://cert-manager.io/docs/configuration/acme/dns01/azuredns/#service-principal) explains what is needed.
 ```sh
 kubectl create secret generic $secret_name \
-    --from-literal=CLIENT_SECRET="$SP_SECRET"
+    --from-literal=SP_SECRET="$SP_SECRET"
 ```
 or using the yaml template:
 ```yaml
@@ -113,13 +114,13 @@ metadata:
     # Otherwise you can set to default, or not use the next field altogether
     namespace:
 data:
-  CLIENT_SECRET:
+  SP_SECRET:
 type: Opaque
 ```
 In addition, a ConfigMap is needed with the less sensitive data:
 ```sh
 kubectl create configmap $configmap \
-    --from-literal=CLIENT_ID="$CLIENT_ID" \
+    --from-literal=SP_ID="$SP_ID" \
     --from-literal=EMAIL_CERT="$EMAIL_CERT" \
     --from-literal=HOSTED_ZONE="$HOSTED_ZONE" \
     --from-literal=RG_NAME="$RG_NAME" \
@@ -137,7 +138,7 @@ metadata:
     # Otherwise you can set to default, or not use the next field altogether
     namespace:
 data:
-  CLIENT_ID:
+  SP_ID:
   EMAIL_CERT:
   HOSTED_ZONE:
   RG_NAME:

--- a/k8s/federated-node/Chart.yaml
+++ b/k8s/federated-node/Chart.yaml
@@ -22,3 +22,9 @@ version: 0.9.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.9.0"
+
+dependencies:
+  - name: cert-manager
+    version: "v1.17.1"
+    repository: https://charts.jetstack.io
+    condition: certmanager.enabled

--- a/k8s/federated-node/Chart.yaml
+++ b/k8s/federated-node/Chart.yaml
@@ -27,4 +27,4 @@ dependencies:
   - name: cert-manager
     version: "v1.17.1"
     repository: https://charts.jetstack.io
-    condition: certmanager.enabled
+    condition: cert-manager.enabled

--- a/k8s/federated-node/Chart.yaml
+++ b/k8s/federated-node/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.0"
+appVersion: "0.10.0"
 
 dependencies:
   - name: cert-manager

--- a/k8s/federated-node/templates/azure-storage-secrets.yaml
+++ b/k8s/federated-node/templates/azure-storage-secrets.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.storage.azure }}
-{{ if not .Values.storage.azure.secret }}
+{{ if not .Values.storage.azure.secretName }}
 {{ if and .Values.storage.azure.storageAccountName .Values.storage.azure.storageAccountKey }}
 kind: Secret
 apiVersion: v1

--- a/k8s/federated-node/templates/certificates-namespace.yaml
+++ b/k8s/federated-node/templates/certificates-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ index .Values "cert-manager" "namespace" }}
+  {{- if .Release.IsInstall }}
+  labels:
+    {{ template "defaultLabels" . }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-6"
+    {{ template "defaultAnnotations" . }}
+  {{- end }}

--- a/k8s/federated-node/templates/certificates/certificate.yaml
+++ b/k8s/federated-node/templates/certificates/certificate.yaml
@@ -1,12 +1,12 @@
 # Only rendered if SSL certificates are needed
-{{- if .Values.certmanager.enabled }}
+{{- if (index .Values "cert-manager" "enabled") }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: www
   namespace: {{ .Release.Namespace }}
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: post-install, post-upgrade
 spec:
   secretName: {{ .Values.ingress.tls.secretName }}
   revisionHistoryLimit: 1

--- a/k8s/federated-node/templates/certificates/certificate.yaml
+++ b/k8s/federated-node/templates/certificates/certificate.yaml
@@ -1,0 +1,23 @@
+# Only rendered if SSL certificates are needed
+{{- if .Values.certmanager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: www
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ .Values.ingress.tls.secretName }}
+  revisionHistoryLimit: 1
+  privateKey:
+    rotationPolicy: Always
+  commonName: {{ .Values.ingress.host }}
+  dnsNames:
+    - {{ .Values.ingress.host }}
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+  issuerRef:
+    name: ssl-issuer
+    kind: ClusterIssuer
+{{- end }}

--- a/k8s/federated-node/templates/certificates/certificate.yaml
+++ b/k8s/federated-node/templates/certificates/certificate.yaml
@@ -5,6 +5,8 @@ kind: Certificate
 metadata:
   name: www
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install
 spec:
   secretName: {{ .Values.ingress.tls.secretName }}
   revisionHistoryLimit: 1

--- a/k8s/federated-node/templates/certificates/issuer.yaml
+++ b/k8s/federated-node/templates/certificates/issuer.yaml
@@ -16,10 +16,10 @@ spec:
     solvers:
     - dns01:
         azureDNS:
-          clientID: {{ $cm.data.CLIENT_ID }}
+          clientID: {{ $cm.data.SP_ID }}
           clientSecretSecretRef:
             name: {{ $.Values.certs.azure }}
-            key: CLIENT_SECRET
+            key: SP_SECRET
           resourceGroupName: {{ $cm.data.RG_NAME }}
           subscriptionID: {{ $cm.data.SUBSCRIPTION_ID }}
           hostedZoneName: {{ $cm.data.HOSTED_ZONE }}

--- a/k8s/federated-node/templates/certificates/issuer.yaml
+++ b/k8s/federated-node/templates/certificates/issuer.yaml
@@ -6,25 +6,24 @@ metadata:
   name: ssl-issuer
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if .Values.local_development }}
-  selfSigned: {}
-  {{- else if .Values.ingress.on_aks }}
+  {{- if .Values.ingress.on_aks }}
+  {{- $cm := lookup "v1" "ConfigMap" $.Release.Namespace .Values.certs.azure.configmap | default dict }}
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: {{ $sec.data.EMAIL_CERT | b64dec }}
+    email: {{ $cm.data.EMAIL_CERT }}
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:
-    - http01:
+    - dns01:
         azureDNS:
+          clientID: {{ $cm.data.CLIENT_ID }}
           clientSecretSecretRef:
-            name: azuredns-config
-            key: client-secret
-          resourceGroupName: {{ $sec.data.RG_NAME | b64dec }}
-          subscriptionID: {{ $sec.data.SUBSCRIPTION_ID | b64dec }}
-          hostedZoneName: {{ .Values.ingress.host }}
-          environment: AzurePublicCloud
-          clientID: {{ $sec.data.CLIENT_ID | b64dec }}
+            name: {{ $.Values.certs.azure }}
+            key: CLIENT_SECRET
+          resourceGroupName: {{ $cm.data.RG_NAME }}
+          subscriptionID: {{ $cm.data.SUBSCRIPTION_ID }}
+          hostedZoneName: {{ $cm.data.HOSTED_ZONE }}
+          tenantID: {{ $cm.data.TENANT_ID }}
   {{- else if .Values.ingress.on_eks }}
   {{- $sec := lookup "v1" "Secret" $.Release.Namespace .Values.certs.aws | default dict }}
   acme:
@@ -41,5 +40,7 @@ spec:
             kubernetes:
               serviceAccountRef:
                 name: cert-manager-acme-dns01-route53
+  {{- else if .Values.local_development }}
+  selfSigned: {}
   {{- end }}
 {{- end }}

--- a/k8s/federated-node/templates/certificates/issuer.yaml
+++ b/k8s/federated-node/templates/certificates/issuer.yaml
@@ -5,6 +5,8 @@ kind: ClusterIssuer
 metadata:
   name: ssl-issuer
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-install
 spec:
   {{- if .Values.ingress.on_aks }}
   {{- $cm := lookup "v1" "ConfigMap" $.Release.Namespace .Values.certs.azure.configmap | default dict }}

--- a/k8s/federated-node/templates/certificates/issuer.yaml
+++ b/k8s/federated-node/templates/certificates/issuer.yaml
@@ -1,12 +1,12 @@
 # Only rendered if SSL certificates are needed
-{{- if .Values.certmanager.enabled }}
+{{- if (index .Values "cert-manager" "enabled" ) }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: ssl-issuer
   namespace: {{ .Release.Namespace }}
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: post-install, post-upgrade
 spec:
   {{- if .Values.ingress.on_aks }}
   {{- $cm := lookup "v1" "ConfigMap" $.Release.Namespace .Values.certs.azure.configmap | default dict }}

--- a/k8s/federated-node/templates/certificates/issuer.yaml
+++ b/k8s/federated-node/templates/certificates/issuer.yaml
@@ -1,0 +1,45 @@
+# Only rendered if SSL certificates are needed
+{{- if .Values.certmanager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ssl-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.local_development }}
+  selfSigned: {}
+  {{- else if .Values.ingress.on_aks }}
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: {{ $sec.data.EMAIL_CERT | b64dec }}
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        azureDNS:
+          clientSecretSecretRef:
+            name: azuredns-config
+            key: client-secret
+          resourceGroupName: {{ $sec.data.RG_NAME | b64dec }}
+          subscriptionID: {{ $sec.data.SUBSCRIPTION_ID | b64dec }}
+          hostedZoneName: {{ .Values.ingress.host }}
+          environment: AzurePublicCloud
+          clientID: {{ $sec.data.CLIENT_ID | b64dec }}
+  {{- else if .Values.ingress.on_eks }}
+  {{- $sec := lookup "v1" "Secret" $.Release.Namespace .Values.certs.aws | default dict }}
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: {{ $sec.data.EMAIL_CERT | b64dec }}
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - dns01:
+        route53:
+          region: {{ $sec.data.REGION | b64dec }}
+          role: arn:aws:iam::{{ $sec.data.ACCOUNT_ID | b64dec }}:role/{{ $sec.data.ROLE_NAME | b64dec }}
+          auth:
+            kubernetes:
+              serviceAccountRef:
+                name: cert-manager-acme-dns01-route53
+  {{- end }}
+{{- end }}

--- a/k8s/federated-node/templates/certificates/issuer.yaml
+++ b/k8s/federated-node/templates/certificates/issuer.yaml
@@ -18,7 +18,7 @@ spec:
         azureDNS:
           clientID: {{ $cm.data.SP_ID }}
           clientSecretSecretRef:
-            name: {{ $.Values.certs.azure }}
+            name: {{ $.Values.certs.azure.secretName }}
             key: SP_SECRET
           resourceGroupName: {{ $cm.data.RG_NAME }}
           subscriptionID: {{ $cm.data.SUBSCRIPTION_ID }}

--- a/k8s/federated-node/templates/certificates/roles.yaml
+++ b/k8s/federated-node/templates/certificates/roles.yaml
@@ -1,0 +1,27 @@
+# Conditional Roles specifically for AWS certificates
+{{- if and .Values.certmanager.enabled .Values.ingress.on_eks }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-acme-dns01-route53-tokenrequest
+  namespace: {{ .Values.certmanager.namespace }}
+rules:
+  - apiGroups: ['']
+    resources: ['serviceaccounts/token']
+    resourceNames: ['cert-manager-acme-dns01-route53']
+    verbs: ['create']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-acme-dns01-route53-tokenrequest
+  namespace: {{ .Values.certmanager.namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-acme-dns01-route53-tokenrequest
+{{- end }}

--- a/k8s/federated-node/templates/certificates/roles.yaml
+++ b/k8s/federated-node/templates/certificates/roles.yaml
@@ -1,10 +1,10 @@
 # Conditional Roles specifically for AWS certificates
-{{- if and .Values.certmanager.enabled .Values.ingress.on_eks }}
+{{- if and (index .Values "cert-manager" "enabled" ) .Values.ingress.on_eks }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-acme-dns01-route53-tokenrequest
-  namespace: {{ .Values.certmanager.namespace }}
+  namespace: {{ (index .Values "cert-manager" "namespace" ) }}
 rules:
   - apiGroups: ['']
     resources: ['serviceaccounts/token']
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-acme-dns01-route53-tokenrequest
-  namespace: {{ .Values.certmanager.namespace }}
+  namespace: {{ (index .Values "cert-manager" "namespace" ) }}
 subjects:
   - kind: ServiceAccount
     name: cert-manager

--- a/k8s/federated-node/templates/copy-sercets.yaml
+++ b/k8s/federated-node/templates/copy-sercets.yaml
@@ -8,9 +8,9 @@ metadata:
   name: {{ . }}
   namespace: {{ $.Values.namespaces.keycloak }}
 data:
-{{- with $sec.data  }}
+{{- with $sec.data }}
 {{ toYaml . | indent 2 }}
 {{- end }}
-type: {{ $sec.type}}
+type: {{ $sec.type }}
 ---
 {{- end }}

--- a/k8s/federated-node/templates/nginx-deployment.1.10.0.yaml
+++ b/k8s/federated-node/templates/nginx-deployment.1.10.0.yaml
@@ -386,7 +386,7 @@ spec:
             - --validating-webhook-key=/usr/local/certificates/key
             - --enable-metrics=false
             {{- if .Values.ingress.tls }}
-            - --default-ssl-certificate={{ .Release.Namespace }}/{{ .Values.ingress.tls.secretName | default "tls" }}
+            - --default-ssl-certificate={{ .Release.Namespace }}/{{ .Values.ingress.tls.secretName }}
             {{- end }}
           securityContext:
             runAsNonRoot: true

--- a/k8s/federated-node/templates/nginx-ingress.yaml
+++ b/k8s/federated-node/templates/nginx-ingress.yaml
@@ -18,7 +18,7 @@ spec:
   - hosts:
     - {{ .Values.ingress.host }}
     {{ if .Values.ingress.tls }}
-    secretName: {{ .Values.ingress.tls.secretName | default "tls"}}
+    secretName: {{ .Values.ingress.tls.secretName }}
     {{ end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/k8s/federated-node/values.yaml
+++ b/k8s/federated-node/values.yaml
@@ -96,8 +96,10 @@ ingress:
     secretName: tls
 
 certs:
-  azure:
-  aws:
+  azure: {}
+    # secret:
+    # configmap:
+  aws: {}
 
 # Enables full smoketests when running `helm test`.
 # This will actively try to add new database and keycloak entries

--- a/k8s/federated-node/values.yaml
+++ b/k8s/federated-node/values.yaml
@@ -97,7 +97,7 @@ ingress:
 
 certs:
   azure: {}
-    # secret:
+    # secretName:
     # configmap:
   aws: {}
 

--- a/k8s/federated-node/values.yaml
+++ b/k8s/federated-node/values.yaml
@@ -83,6 +83,7 @@ securityContext: {}
 ingress:
   host:
   on_aks: false
+  on_eks: false
   whitelist:
     enabled: false
     ips: []
@@ -92,7 +93,11 @@ ingress:
   tls:
     keyFile:
     certFile:
-    # secretName:
+    secretName: tls
+
+certs:
+  azure:
+  aws:
 
 # Enables full smoketests when running `helm test`.
 # This will actively try to add new database and keycloak entries
@@ -107,3 +112,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+certmanager:
+  namespace: fn-certmanager
+  enabled: false

--- a/k8s/federated-node/values.yaml
+++ b/k8s/federated-node/values.yaml
@@ -115,6 +115,7 @@ tolerations: []
 
 affinity: {}
 
-certmanager:
-  namespace: fn-certmanager
+cert-manager:
   enabled: false
+  namespace: fn-certmanager
+  installCRDs: true

--- a/scripts/upgrade_subchart.py
+++ b/scripts/upgrade_subchart.py
@@ -1,0 +1,51 @@
+"""
+Simple script that opens the Chart.yaml file and
+replaces the given subchart version with the one provided
+in input
+"""
+
+import logging
+import re
+import sys
+from argparse import ArgumentParser
+
+CHART_FILE = "k8s/federated-node/Chart.yaml"
+
+logger = logging.getLogger("bumper")
+logger.setLevel(logging.INFO)
+
+parser = ArgumentParser(
+    prog="Subchart Version Bumper",
+    description="Upgrades the version of this Chart's dependency"
+)
+
+parser.add_argument('-s', '--subchart', required=True, type=str)
+parser.add_argument('-v', '--version', required=True)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    with open(CHART_FILE) as f:
+        chart_file = f.readlines()
+
+    for idx, line in enumerate(chart_file):
+        if re.match(f'.*name: {args.subchart}', line):
+            s_idx = idx + 1
+            while s_idx < len(chart_file):
+                if re.match('.*version:', chart_file[s_idx]):
+                    chart_file[s_idx] = re.sub(': .*\n', f': "{args.version}"\n', chart_file[s_idx])
+                    break
+                if re.match(' +-', chart_file[s_idx]):
+                    logger.error("Subchart %s missing version", args.subchart)
+                    sys.exit(1)
+                s_idx += 1
+            break
+
+    if s_idx == len(chart_file):
+        logger.error("Subchart %s missing version", args.subchart)
+        sys.exit(1)
+
+    with open(CHART_FILE, "w") as f:
+        f.write("".join(chart_file))
+    logger.info("Successfully updated to %s", args.version)


### PR DESCRIPTION
Certificate management with `certmanager` added
This feature is optional and inactive by default. To enable it, set `certmanager.enabled: true`
It supports Azure and AWS (untested, only based on the documentation guidelines)

Modified the bump version pipeline to separate each subchart from the main chart version.