### PR TITLE
dataset-project: Now the datasets are strictly linked to a user and p…

### DIFF
--- a/webserver/app/datasets_api.py
+++ b/webserver/app/datasets_api.py
@@ -7,7 +7,6 @@ datasets-related endpoints:
 - GET /datasets/id/dictionaries
 - GET /datasets/id/dictionaries/table_name
 - POST /datasets/token_transfer
-- POST /datasets/workspace/token
 - POST /datasets/selection/beacon
 """
 import json
@@ -132,7 +131,8 @@ def patch_datasets_by_id_or_name(dataset_id:int=None, dataset_name:str=None):
                     "displayName": f"{ds.id} - {ds.name}"
                 }
 
-                req_by = json.loads(dar[0]).get("email")
+                user = Keycloak().get_user_by_id(dar[0])
+                req_by = user["email"]
                 kc_client = Keycloak(client=f"Request {req_by} - {dar[1]}")
                 kc_client.patch_resource(f"{ds.id}-{old_ds_name}", **update_args)
         # Update catalogue and dictionaries
@@ -240,16 +240,6 @@ def post_transfer_token():
     except:
         session.rollback()
         raise
-
-@bp.route('/workspace/token', methods=['POST'])
-@audit
-@auth(scope='can_transfer_token', check_dataset=False)
-def post_workspace_transfer_token():
-    """
-    POST /datasets/workspace/token endpoint.
-        Sends a user's token based on an approved DAR to an approved third-party
-    """
-    return "WIP", 200
 
 @bp.route('/selection/beacon', methods=['POST'])
 @audit

--- a/webserver/app/helpers/keycloak.py
+++ b/webserver/app/helpers/keycloak.py
@@ -641,6 +641,21 @@ class Keycloak:
 
         raise KeycloakError("Failed to fetch the created user")
 
+    def get_user_by_id(self, user_id:str) -> dict:
+        """
+        Method to return a dictionary representing a Keycloak user,
+        checks for both username and email
+        """
+        username_encoded = urllib.parse.quote_plus(user_id)
+        user_response = requests.get(
+            f"{URLS["user"]}/{username_encoded}",
+            headers={"Authorization": f"Bearer {self.admin_token}"}
+        )
+        if not user_response.ok:
+            raise KeycloakError("Failed to fetch the user")
+
+        return user_response.json() if user_response.json() else None
+
     def get_user_by_username(self, username:str) -> dict:
         """
         Method to return a dictionary representing a Keycloak user

--- a/webserver/app/helpers/kubernetes.py
+++ b/webserver/app/helpers/kubernetes.py
@@ -368,6 +368,7 @@ class KubernetesClient(KubernetesBase, client.CoreV1Api):
                 if e.status == 409:
                     pass
                 else:
+                    logger.error(e.body)
                     raise InvalidRequest(e.reason)
         return body
 

--- a/webserver/app/helpers/wrappers.py
+++ b/webserver/app/helpers/wrappers.py
@@ -7,6 +7,7 @@ from app.helpers.exceptions import AuthenticationError, UnauthorizedError, DBRec
 from app.helpers.keycloak import Keycloak
 from app.models.audit import Audit
 from app.models.dataset import Dataset
+from app.models.request import Request
 
 
 logger = logging.getLogger('wrappers')
@@ -26,7 +27,17 @@ def auth(scope:str, check_dataset=True):
             client = 'global'
             token_type = 'refresh_token'
 
-            if check_dataset:
+            kc_client = Keycloak()
+            token_info = kc_client.decode_token(token)
+            user = kc_client.get_user_by_username(token_info['username'])
+
+            if requested_project:
+                dar = Request.get_active_project(requested_project, user["id"])
+                if dar.dataset_id:
+                    ds = Dataset.get_dataset_by_name_or_id(id=dar.dataset_id)
+                    resource = f"{ds.id}-{ds.name}"
+
+            elif check_dataset:
                 ds_id = kwargs.get("dataset_id")
                 ds_name = kwargs.get("dataset_name", "")
 
@@ -38,10 +49,6 @@ def auth(scope:str, check_dataset=True):
                 if ds_id or ds_name:
                     ds = Dataset.get_dataset_by_name_or_id(name=ds_name, id=ds_id)
                     resource = f"{ds.id}-{ds.name}"
-
-            kc_client = Keycloak()
-            token_info = kc_client.decode_token(token)
-            user = kc_client.get_user_by_username(token_info['username'])
 
             # If the user is an admin or system, ignore the project
             if not kc_client.has_user_roles(user["id"], {"Administrator", "System"}):

--- a/webserver/app/models/task.py
+++ b/webserver/app/models/task.py
@@ -19,6 +19,7 @@ from app.helpers.kubernetes import KubernetesBatchClient, KubernetesClient
 from app.helpers.exceptions import DBError, InvalidRequest, TaskImageException, TaskExecutionException
 from app.models.dataset import Dataset
 from app.models.container import Container
+from app.models.request import Request
 
 logger = logging.getLogger('task_model')
 logger.setLevel(logging.INFO)
@@ -66,19 +67,26 @@ class Task(db.Model, BaseModel):
 
     @classmethod
     def validate(cls, data:dict):
-        data["requested_by"] = Keycloak().decode_token(
-            Keycloak.get_token_from_headers()
-        ).get('sub')
+        kc_client = Keycloak()
+        user_token = Keycloak.get_token_from_headers()
+        data["requested_by"] = kc_client.decode_token(user_token).get('sub')
+        user = kc_client.get_user_by_id(data["requested_by"])
         # Support only for one image at a time, the standard is executors == list
         executors = data["executors"][0]
         data["docker_image"] = executors["image"]
         data = super().validate(data)
 
         # Dataset validation
-        ds_id = data.get("tags", {}).get("dataset_id")
-        ds_name = data.get("tags", {}).get("dataset_name")
-        if ds_name or ds_id:
-            data["dataset"] = Dataset.get_dataset_by_name_or_id(name=ds_name, id=ds_id)
+        if kc_client.is_user_admin(user_token):
+            ds_id = data.get("tags", {}).get("dataset_id")
+            ds_name = data.get("tags", {}).get("dataset_name")
+            if ds_name or ds_id:
+                data["dataset"] = Dataset.get_dataset_by_name_or_id(name=ds_name, id=ds_id)
+        else:
+            data["dataset"] = Request.get_active_project(
+                data["project_name"],
+                user["id"]
+            ).dataset
 
         # Docker image validation
         if not re.match(r'^((\w+|-|\.)\/?+)+:(\w+(\.|-)?)+$', data["docker_image"]):

--- a/webserver/app/static/openapi.json
+++ b/webserver/app/static/openapi.json
@@ -1745,14 +1745,11 @@
             "required": ["dataset_id"]
           },
           "outputs": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "An object where the key is a human readable name and the value is the path to which a volume will be mounted on at run time to fetch the results. The key value, in the example folder1, will be used as folder name in the results archive as well.",
-              "example": {
-                "folder1": "/mnt/data/results",
-                "folder2": "/home/john/analysis/csvs"
-              }
+            "type": "object",
+            "description": "An object where the key is a human readable name and the value is the path to which a volume will be mounted on at run time to fetch the results. The key value, in the example folder1, will be used as folder name in the results archive as well.",
+            "example": {
+              "folder1": "/mnt/data/results",
+              "folder2": "/home/john/analysis/csvs"
             }
           },
           "resources": {

--- a/webserver/app/tasks_api.py
+++ b/webserver/app/tasks_api.py
@@ -89,7 +89,9 @@ def post_tasks():
     POST /tasks/ endpoint. Creates a new task
     """
     try:
-        body = Task.validate(request.json)
+        req_body = request.json
+        req_body["project_name"] = request.headers.get("project-name")
+        body = Task.validate(req_body)
         task = Task(**body)
         task.add()
         # Create pod/start ML pipeline
@@ -107,7 +109,9 @@ def post_tasks_validate():
     POST /tasks/validate endpoint.
         Allows task definition validation and the DB query that will be used
     """
-    Task.validate(request.json)
+    req_body = request.json
+    req_body["project_name"] = request.headers.get("project-name")
+    Task.validate(req_body)
     return "Ok", 200
 
 @bp.route('/<task_id>/results', methods=['GET'])

--- a/webserver/tests/conftest.py
+++ b/webserver/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 import os
 import pytest
 import requests
+from uuid import uuid4
 from datetime import datetime as dt, timedelta
 from kubernetes.client import V1Pod
 from sqlalchemy.orm.session import close_all_sessions
@@ -13,6 +14,7 @@ from app import create_app
 from app.helpers.db import db
 from app.models.dataset import Dataset
 from app.models.request import Request
+from app.models.task import Task
 from app.helpers.keycloak import Keycloak, URLS, KEYCLOAK_SECRET, KEYCLOAK_CLIENT
 from tests.helpers.keycloak import clean_kc
 from app.helpers.exceptions import KeycloakError
@@ -244,21 +246,33 @@ def dataset(mocker, client, user_uuid, k8s_client):
     return dataset
 
 @pytest.fixture
-def dataset2(client, user_uuid, k8s_client):
+def dataset2(mocker, client, user_uuid, k8s_client):
+    mocker.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=True)
     dataset = Dataset(name="AnotherDS", host="example.com", password='pass', username='user')
     dataset.add(user_id=user_uuid)
     return dataset
+
+@pytest.fixture
+def task(basic_user, image_name, dataset) -> Task:
+    task = Task(
+        dataset=dataset,
+        docker_image=image_name,
+        name="testTask",
+        requested_by=basic_user["id"]
+    )
+    task.add()
+    return task
 
 @pytest.fixture
 def dar_user():
     return "some@test.com"
 
 @pytest.fixture
-def access_request(client, dataset, user_uuid, k8s_client, dar_user):
+def access_request(dataset, user_uuid, k8s_client, dar_user):
     request = Request(
         title="TestRequest",
         project_name="example.com",
-        requested_by=json.dumps({"email": dar_user}),
+        requested_by=user_uuid,
         dataset=dataset,
         proj_start=dt.now().date().strftime("%Y-%m-%d"),
         proj_end=(dt.now().date() + timedelta(days=10)).strftime("%Y-%m-%d")
@@ -298,7 +312,7 @@ def side_effect(dict_mock:dict):
 @pytest.fixture
 def request_base_body(dataset):
     return {
-        "title": "Test Task",
+        "title": "TestRequest",
         "dataset_id": dataset.id,
         "project_name": "project1",
         "requested_by": { "email": "test@test.com" },
@@ -306,6 +320,15 @@ def request_base_body(dataset):
         "proj_start": dt.now().date().strftime("%Y-%m-%d"),
         "proj_end": (dt.now().date() + timedelta(days=10)).strftime("%Y-%m-%d")
     }
+
+@pytest.fixture
+def request_model_body(request_base_body, dataset):
+    req_model = copy.deepcopy(request_base_body)
+    req_model.pop("dataset_id")
+    req_model["dataset"] = dataset
+    req_model["requested_by"] = json.dumps(req_model["requested_by"])
+
+    return req_model
 
 @pytest.fixture
 def approve_request(mocker):
@@ -321,3 +344,31 @@ def new_user_email():
 @pytest.fixture
 def new_user(new_user_email):
     return Keycloak().create_user(set_temp_pass=True, **{"email": new_user_email})
+
+@pytest.fixture
+def mocks_kc_tasks(mocker, dar_user):
+    user_uuid = str(uuid4())
+    return {
+        "wrappers": mocker.patch(
+            'app.helpers.wrappers.Keycloak',
+            return_value=Mock(
+                exchange_global_token=Mock(return_value=""),
+                get_token_from_headers=Mock(return_value=""),
+                is_token_valid=Mock(return_value=True),
+                is_user_admin=Mock(return_value=True),
+                get_user_by_username=Mock(return_value={"id": user_uuid}),
+                decode_token=Mock(return_value={
+                    "username": "test_user", "sub": user_uuid
+                }),
+            )
+        ),
+        "tasks": mocker.patch(
+            'app.models.task.Keycloak',
+            return_value=Mock(
+                get_user_by_id=Mock(return_value={"email": dar_user}),
+                decode_token=Mock(return_value={
+                    "username": "test_user", "sub": user_uuid
+                }),
+            )
+        )
+    }

--- a/webserver/tests/test_tasks.py
+++ b/webserver/tests/test_tasks.py
@@ -78,427 +78,277 @@ def terminated_state():
             waiting=None
         )
     )
-
-def test_get_list_tasks(
-        client,
-        simple_admin_header
-    ):
-    """
-    Tests that admin users can see the list of tasks
-    """
-    response = client.get(
-        '/tasks/',
-        headers=simple_admin_header
-    )
-    assert response.status_code == 200
-
-def test_get_list_tasks_base_user(
-        client,
-        simple_user_header
-    ):
-    """
-    Tests that non-admin users cannot see the list of tasks
-    """
-    response = client.get(
-        '/tasks/',
-        headers=simple_user_header
-    )
-    assert response.status_code == 403
-
-def test_create_task(
-        cr_client,
-        post_json_admin_header,
-        client,
-        registry_client,
-        task_body
-    ):
-    """
-    Tests task creation returns 201
-    """
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-
-def test_create_task_invalid_output_field(
-        cr_client,
-        post_json_admin_header,
-        client,
-        registry_client,
-        task_body
-    ):
-    """
-    Tests task creation returns 4xx request when output
-    is not a dictionary
-    """
-    task_body["outputs"] = []
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 400
-    assert response.json == {"error": "\"outputs\" filed muct be a json object or dictionary"}
-
-def test_create_task_no_output_field_reverts_to_default(
-        cr_client,
-        reg_k8s_client,
-        post_json_admin_header,
-        client,
-        registry_client,
-        task_body
-    ):
-    """
-    Tests task creation returns 201 but the volume mounted
-    is the default one
-    """
-    task_body.pop("outputs")
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-    reg_k8s_client["create_namespaced_pod_mock"].assert_called()
-    pod_body = reg_k8s_client["create_namespaced_pod_mock"].call_args.kwargs["body"]
-    assert len(pod_body.spec.containers[0].volume_mounts) == 1
-    assert pod_body.spec.containers[0].volume_mounts[0].mount_path == TASK_POD_RESULTS_PATH
-
-def test_create_task_with_ds_name(
-        cr_client,
-        post_json_admin_header,
-        client,
-        registry_client,
-        dataset,
-        task_body
-    ):
-    """
-    Tests task creation with a dataset name returns 201
-    """
-    data = task_body
-    data["tags"].pop("dataset_id")
-    data["tags"]["dataset_name"] = dataset.name
-
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(data),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-
-def test_create_task_with_ds_name_and_id(
-        cr_client,
-
-        post_json_admin_header,
-        client,
-        registry_client,
-        dataset,
-        task_body
-    ):
-    """
-    Tests task creation with a dataset name and id returns 201
-    """
-    data = task_body
-    data["tags"]["dataset_name"] = dataset.name
-
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(data),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-
-def test_create_task_with_conflicting_ds_name_and_id(
-        cr_client,
-
-        post_json_admin_header,
-        client,
-        dataset,
-        task_body
-    ):
-    """
-    Tests task creation with a dataset name that does not exists
-    and a valid id returns 201
-    """
-    data = task_body
-    data["tags"]["dataset_name"] = "something else"
-
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(data),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 404
-    assert response.json["error"] == f"Dataset \"something else\" with id {dataset.id} does not exist"
-
-def test_create_task_with_non_existing_dataset(
-        cr_client,
-        post_json_admin_header,
-        client,
-        task_body
-    ):
-    """
-    Tests task creation returns 404 when the requested dataset doesn't exist
-    """
-    data = task_body
-    data["dataset_id"] = '123456'
-
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(data),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 404
-    assert response.json == {"error": "Dataset 123456 does not exist"}
-
-def test_create_task_with_non_existing_dataset_name(
-        cr_client,
-        post_json_admin_header,
-        client,
-        dataset,
-        task_body
-    ):
-    """
-    Tests task creation returns 404 when the
-    requested dataset name doesn't exist
-    """
-    data = task_body
-    data["tags"].pop("dataset_id")
-    data["tags"]["dataset_name"] = "something else"
-
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(data),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 404
-    assert response.json == {"error": "Dataset something else does not exist"}
-
-@mock.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=False)
-def test_create_unauthorized_task(
-        kc_valid_mock,
-        cr_client,
-        post_json_user_header,
-        dataset,
-        client,
-        task_body
-    ):
-    """
-    Tests task creation returns 403 if a user is not authorized to
-    access the dataset
-    """
-    data = task_body
-    data["dataset_id"] = dataset.id
-
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(data),
-        headers=post_json_user_header
-    )
-    assert response.status_code == 403
-
-def test_create_task_image_not_found(
-        cr_client_404,
-        post_json_admin_header,
-        client,
-        task_body
-    ):
-    """
-    Tests task creation returns 500 with a requested docker image is not found
-    """
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 500
-    assert response.json == {"error": f"Image {task_body["executors"][0]["image"]} not found on our repository"}
-
-@mock.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=True)
-def test_get_task_by_id_admin(
-        token_valid_mock,
-        cr_client,
-
-        post_json_admin_header,
-        post_json_user_header,
-        simple_admin_header,
-        client,
-        registry_client,
-        task_body
-    ):
-    """
-    If an admin wants to check a specific task they should be allowed regardless
-    of who requested it
-    """
-    resp = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_user_header
-    )
-    assert resp.status_code == 201
-    task_id = resp.json["task_id"]
-
-    resp = client.get(
-        f'/tasks/{task_id}',
-        headers=simple_admin_header
-    )
-    assert resp.status_code == 200
-
-@mock.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=True)
-def test_get_task_by_id_non_admin_owner(
-        token_valid_mock,
-        cr_client,
-
-        simple_user_header,
-        post_json_user_header,
-        client,
-        registry_client,
-        task_body
-    ):
-    """
-    If a user wants to check a specific task they should be allowed if they did request it
-    """
-    resp = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_user_header
-    )
-    assert resp.status_code == 201
-    task_id = resp.json["task_id"]
-
-    resp = client.get(
-        f'/tasks/{task_id}',
-        headers=simple_user_header
-    )
-    assert resp.status_code == 200
-
-@mock.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=True)
-def test_get_task_by_id_non_admin_non_owner(
-        token_valid_mock,
-        cr_client,
-
-        post_json_user_header,
-        simple_user_header,
-        client,
-        registry_client,
-        task_body
-    ):
-    """
-    If a user wants to check a specific task they should not be allowed if they did not request it
-    """
-    resp = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_user_header
-    )
-    assert resp.status_code == 201
-    task_id = resp.json["task_id"]
-
-    task_obj = db.session.get(Task, task_id)
-    task_obj.requested_by = "some random uuid"
-
-    resp = client.get(
-        f'/tasks/{task_id}',
-        headers=simple_user_header
-    )
-    assert resp.status_code == 403
-
-def test_cancel_task(
-        client,
-        cr_client,
-
-        registry_client,
-        simple_admin_header,
-        post_json_admin_header,
-        task_body
-    ):
-    """
-    Test that an admin can cancel an existing task
-    """
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-
-    response = client.post(
-        f'/tasks/{response.json['task_id']}/cancel',
-        headers=simple_admin_header
-    )
-    assert response.status_code == 201
-
-def test_cancel_404_task(
-        client,
-        simple_admin_header
-    ):
-    """
-    Test that an admin can cancel a non-existing task returns a 404
-    """
-    response = client.post(
-        '/tasks/123456/cancel',
-        headers=simple_admin_header
-    )
-    assert response.status_code == 404
-
-def test_validate_task(
-        client,
-        task_body,
-        cr_client,
-        registry_client,
-        post_json_admin_header
-    ):
-    """
-    Test the validation endpoint can be used by admins returns 201
-    """
-    response = client.post(
-        '/tasks/validate',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 200
-
-def test_validate_task_basic_user(
-        client,
-        task_body,
-        cr_client,
-        registry_client,
-        post_json_user_header
-    ):
-    """
-    Test the validation endpoint can be used by non-admins returns 201
-    """
-    response = client.post(
-        '/tasks/validate',
-        data=json.dumps(task_body),
-        headers=post_json_user_header
-    )
-    assert response.status_code == 200
-
-
-class TestTaskResults:
-    def test_get_results(
-        self,
-        cr_client,
-        registry_client,
-        post_json_admin_header,
-        simple_admin_header,
-        client,
-        task_body,
-        mocker,
-        reg_k8s_client
-    ):
+class TestGetTasks:
+    def test_get_list_tasks(
+            self,
+            client,
+            simple_admin_header
+        ):
         """
-        A simple test with mocked PVs to test a successful result
-        fetch
+        Tests that admin users can see the list of tasks
         """
-        # Create a new task
+        response = client.get(
+            '/tasks/',
+            headers=simple_admin_header
+        )
+        assert response.status_code == 200
+
+    def test_get_list_tasks_base_user(
+            self,
+            client,
+            simple_user_header
+        ):
+        """
+        Tests that non-admin users cannot see the list of tasks
+        """
+        response = client.get(
+            '/tasks/',
+            headers=simple_user_header
+        )
+        assert response.status_code == 403
+
+    def test_get_task_by_id_admin(
+            self,
+            mocks_kc_tasks,
+            cr_client,
+            post_json_admin_header,
+            post_json_user_header,
+            simple_admin_header,
+            client,
+            registry_client,
+            task_body
+        ):
+        """
+        If an admin wants to check a specific task they should be allowed regardless
+        of who requested it
+        """
+        resp = client.post(
+            '/tasks/',
+            data=json.dumps(task_body),
+            headers=post_json_user_header
+        )
+        assert resp.status_code == 201
+        task_id = resp.json["task_id"]
+
+        resp = client.get(
+            f'/tasks/{task_id}',
+            headers=simple_admin_header
+        )
+        assert resp.status_code == 200
+
+    @mock.patch('app.helpers.keycloak.Keycloak.is_user_admin', return_value=False)
+    @mock.patch('app.tasks_api.Keycloak.decode_token')
+    def test_get_task_by_id_non_admin_owner(
+            self,
+            mocks_decode,
+            mocks_is_admin,
+            mocks_kc_tasks,
+            simple_user_header,
+            client,
+            basic_user,
+            task
+        ):
+        """
+        If a user wants to check a specific task they should be allowed if they did request it
+        """
+        mocks_decode.return_value = {"sub": basic_user["id"]}
+        resp = client.get(
+            f'/tasks/{task.id}',
+            headers=simple_user_header
+        )
+        assert resp.status_code == 200, resp.json
+
+    @mock.patch('app.helpers.keycloak.Keycloak.is_user_admin', return_value=False)
+    def test_get_task_by_id_non_admin_non_owner(
+            self,
+            mock_is_admin,
+            mocks_kc_tasks,
+            simple_user_header,
+            client,
+            task
+        ):
+        """
+        If a user wants to check a specific task they should not be allowed if they did not request it
+        """
+        task_obj = db.session.get(Task, task.id)
+        task_obj.requested_by = "some random uuid"
+
+        resp = client.get(
+            f'/tasks/{task.id}',
+            headers=simple_user_header
+        )
+        assert resp.status_code == 403
+
+
+    def test_get_task_status_running_and_waiting(
+            self,
+            cr_client,
+            registry_client,
+            running_state,
+            waiting_state,
+            post_json_admin_header,
+            client,
+            task_body,
+            mocker,
+            task
+        ):
+        """
+        Test to verify the correct task status when it's
+        waiting or Running on k8s. Output would be similar
+        """
+        mocker.patch(
+            'app.models.task.Task.get_current_pod',
+            return_value=Mock(
+                status=Mock(
+                    container_statuses=[running_state]
+                )
+            )
+        )
+
+        response_id = client.get(
+            f'/tasks/{task.id}',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response_id.status_code == 200
+        assert response_id.json["status"] == {'running': {'started_at': '1/1/2024'}}
+
+        mocker.patch(
+            'app.models.task.Task.get_current_pod',
+            return_value=Mock(
+                status=Mock(
+                    container_statuses=[waiting_state]
+                )
+            )
+        )
+
+        response_id = client.get(
+            f'/tasks/{task.id}',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response_id.status_code == 200
+        assert response_id.json["status"] == {'waiting': {'started_at': '1/1/2024'}}
+
+    def test_get_task_status_terminated(
+            self,
+            terminated_state,
+            post_json_admin_header,
+            client,
+            task_body,
+            mocker,
+            task
+        ):
+        """
+        Test to verify the correct task status when it's terminated on k8s
+        """
+        mocker.patch(
+            'app.models.task.Task.get_current_pod',
+            return_value=Mock(
+                status=Mock(
+                    container_statuses=[terminated_state]
+                )
+            )
+        )
+
+        response_id = client.get(
+            f'/tasks/{task.id}',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response_id.status_code == 200
+        expected_status = {
+            'terminated': {
+                'started_at': '1/1/2024',
+                'finished_at': '1/1/2024',
+                'reason': 'Completed successfully!',
+                'exit_code': 0
+            }
+        }
+        assert response_id.json["status"] == expected_status
+
+
+class TestPostTask:
+    def test_create_task(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            registry_client,
+            task_body
+        ):
+        """
+        Tests task creation returns 201
+        """
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 201
+
+    def test_create_task_invalid_output_field(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            registry_client,
+            task_body
+        ):
+        """
+        Tests task creation returns 4xx request when output
+        is not a dictionary
+        """
+        task_body["outputs"] = []
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 400
+        assert response.json == {"error": "\"outputs\" filed muct be a json object or dictionary"}
+
+    def test_create_task_no_output_field_reverts_to_default(
+            self,
+            cr_client,
+            reg_k8s_client,
+            post_json_admin_header,
+            client,
+            registry_client,
+            task_body
+        ):
+        """
+        Tests task creation returns 201 but the volume mounted
+        is the default one
+        """
+        task_body.pop("outputs")
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 201
+        reg_k8s_client["create_namespaced_pod_mock"].assert_called()
+        pod_body = reg_k8s_client["create_namespaced_pod_mock"].call_args.kwargs["body"]
+        assert len(pod_body.spec.containers[0].volume_mounts) == 1
+        assert pod_body.spec.containers[0].volume_mounts[0].mount_path == TASK_POD_RESULTS_PATH
+
+    def test_create_task_with_ds_name(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            registry_client,
+            dataset,
+            task_body
+        ):
+        """
+        Tests task creation with a dataset name returns 201
+        """
         data = task_body
-        # The mock has to be done manually rather than use the fixture
-        # as it complains about the return value of the list_pod method
-        mocker.patch('app.models.task.uuid4', return_value="1dc6c6d1-417f-409a-8f85-cb9d20f7c741")
+        data["tags"].pop("dataset_id")
+        data["tags"]["dataset_name"] = dataset.name
+
         response = client.post(
             '/tasks/',
             data=json.dumps(data),
@@ -506,10 +356,237 @@ class TestTaskResults:
         )
         assert response.status_code == 201
 
+    def test_create_task_with_ds_name_and_id(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            registry_client,
+            dataset,
+            task_body
+        ):
+        """
+        Tests task creation with a dataset name and id returns 201
+        """
+        data = task_body
+        data["tags"]["dataset_name"] = dataset.name
+
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(data),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 201
+
+    def test_create_task_with_conflicting_ds_name_and_id(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            dataset,
+            task_body
+        ):
+        """
+        Tests task creation with a dataset name that does not exists
+        and a valid id returns 201
+        """
+        data = task_body
+        data["tags"]["dataset_name"] = "something else"
+
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(data),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 404
+        assert response.json["error"] == f"Dataset \"something else\" with id {dataset.id} does not exist"
+
+    def test_create_task_with_non_existing_dataset(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            task_body
+        ):
+        """
+        Tests task creation returns 404 when the requested dataset doesn't exist
+        """
+        data = task_body
+        data["dataset_id"] = '123456'
+
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(data),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 404
+        assert response.json == {"error": "Dataset 123456 does not exist"}
+
+    def test_create_task_with_non_existing_dataset_name(
+            self,
+            cr_client,
+            post_json_admin_header,
+            client,
+            dataset,
+            task_body
+        ):
+        """
+        Tests task creation returns 404 when the
+        requested dataset name doesn't exist
+        """
+        data = task_body
+        data["tags"].pop("dataset_id")
+        data["tags"]["dataset_name"] = "something else"
+
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(data),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 404
+        assert response.json == {"error": "Dataset something else does not exist"}
+
+    @mock.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=False)
+    def test_create_unauthorized_task(
+            self,
+            kc_valid_mock,
+            cr_client,
+            post_json_user_header,
+            dataset,
+            client,
+            task_body
+        ):
+        """
+        Tests task creation returns 403 if a user is not authorized to
+        access the dataset
+        """
+        data = task_body
+        data["dataset_id"] = dataset.id
+
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(data),
+            headers=post_json_user_header
+        )
+        assert response.status_code == 403
+
+    def test_create_task_image_not_found(
+            self,
+            cr_client_404,
+            post_json_admin_header,
+            client,
+            task_body
+        ):
+        """
+        Tests task creation returns 500 with a requested docker image is not found
+        """
+        response = client.post(
+            '/tasks/',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 500
+        assert response.json == {"error": f"Image {task_body["executors"][0]["image"]} not found on our repository"}
+
+
+class TestCancelTask:
+    def test_cancel_task(
+            self,
+            client,
+            simple_admin_header,
+            task
+        ):
+        """
+        Test that an admin can cancel an existing task
+        """
+        response = client.post(
+            f'/tasks/{task.id}/cancel',
+            headers=simple_admin_header
+        )
+        assert response.status_code == 201
+
+    def test_cancel_404_task(
+            self,
+            client,
+            simple_admin_header
+        ):
+        """
+        Test that an admin can cancel a non-existing task returns a 404
+        """
+        response = client.post(
+            '/tasks/123456/cancel',
+            headers=simple_admin_header
+        )
+        assert response.status_code == 404
+
+
+class TestValidateTask:
+    def test_validate_task(
+            self,
+            client,
+            task_body,
+            cr_client,
+            registry_client,
+            post_json_admin_header
+        ):
+        """
+        Test the validation endpoint can be used by admins returns 201
+        """
+        response = client.post(
+            '/tasks/validate',
+            data=json.dumps(task_body),
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 200
+
+    def test_validate_task_basic_user(
+            self,
+            mocks_kc_tasks,
+            mocker,
+            client,
+            task_body,
+            cr_client,
+            registry_client,
+            post_json_user_header: dict[str, str],
+            access_request,
+            user_uuid,
+            dar_user
+        ):
+        """
+        Test the validation endpoint can be used by non-admins returns 201
+        """
+        mocks_kc_tasks["wrappers"].return_value.get_user_by_username.return_value = {"id": user_uuid}
+
+        post_json_user_header["project-name"] = access_request.project_name
+        response = client.post(
+            '/tasks/validate',
+            data=json.dumps(task_body),
+            headers=post_json_user_header
+        )
+        assert response.status_code == 200, response.json
+
+
+class TestTaskResults:
+    def test_get_results(
+        self,
+        simple_admin_header,
+        client,
+        mocker,
+        reg_k8s_client,
+        task
+    ):
+        """
+        A simple test with mocked PVs to test a successful result
+        fetch
+        """
+        # The mock has to be done manually rather than use the fixture
+        # as it complains about the return value of the list_pod method
+        mocker.patch('app.models.task.uuid4', return_value="1dc6c6d1-417f-409a-8f85-cb9d20f7c741")
+
         pod_mock = Mock()
         pod_mock.metadata.labels = {"job-name": "result-job-1dc6c6d1-417f-409a-8f85-cb9d20f7c741"}
         pod_mock.metadata.name = "result-job-1dc6c6d1-417f-409a-8f85-cb9d20f7c741"
-        pod_mock.spec.containers = [Mock(image=task_body["executors"][0]["image"])]
+        pod_mock.spec.containers = [Mock(image=task.docker_image)]
         pod_mock.status.container_statuses = [Mock(ready=True)]
         reg_k8s_client["list_namespaced_pod_mock"].return_value.items = [pod_mock]
 
@@ -519,7 +596,7 @@ class TestTaskResults:
         )
 
         response = client.get(
-            f'/tasks/{response.json["task_id"]}/results',
+            f'/tasks/{task.id}/results',
             headers=simple_admin_header
         )
         assert response.status_code == 200
@@ -527,40 +604,27 @@ class TestTaskResults:
 
     def test_get_results_job_creation_failure(
         self,
-        cr_client,
-        registry_client,
-        post_json_admin_header,
         simple_admin_header,
         client,
-        task_body,
-        reg_k8s_client
+        reg_k8s_client,
+        task
     ):
         """
         Tests that the job creation to fetch results from a PV returns a 500
         error code
         """
-        # Create a new task
-        data = task_body
-
-        response = client.post(
-            '/tasks/',
-            data=json.dumps(data),
-            headers=post_json_admin_header
-        )
-        assert response.status_code == 201
-
         # Get results - creating a job fails
         reg_k8s_client["create_namespaced_job_mock"].side_effect = ApiException(status=500, reason="Something went wrong")
 
         pod_mock = Mock()
         pod_mock.metadata.labels = {"job-name": "result-job-1dc6c6d1-417f-409a-8f85-cb9d20f7c741"}
         pod_mock.metadata.name = "result-job-1dc6c6d1-417f-409a-8f85-cb9d20f7c741"
-        pod_mock.spec.containers = [Mock(image=task_body["executors"][0]["image"])]
+        pod_mock.spec.containers = [Mock(image=task.docker_image)]
         pod_mock.status.container_statuses = [Mock(ready=True)]
         reg_k8s_client["list_namespaced_pod_mock"].return_value.items = [pod_mock]
 
         response = client.get(
-            f'/tasks/{response.json["task_id"]}/results',
+            f'/tasks/{task.id}/results',
             headers=simple_admin_header
         )
         assert response.status_code == 400
@@ -570,20 +634,12 @@ class TestTaskResults:
         self,
         simple_admin_header,
         client,
-        dataset
+        task
     ):
         """
         A task result are being deleted after a declared number of days.
         This test makes sure an error is returned as expected
         """
-        task = Task(
-            name="task",
-            docker_image="image:tag",
-            description="something",
-            requested_by="abc123-412-51251-213-412",
-            dataset=dataset
-        )
-        task.add()
         task.created_at=datetime.now() - timedelta(days=CLEANUP_AFTER_DAYS)
         response = client.get(
             f'/tasks/{task.id}/results',
@@ -592,109 +648,12 @@ class TestTaskResults:
         assert response.status_code == 500
         assert response.json["error"] == 'Tasks results are not available anymore. Please, run the task again'
 
-def test_get_task_status_running_and_waiting(
-    cr_client,
-    registry_client,
-    running_state,
-    waiting_state,
-    post_json_admin_header,
-    client,
-    task_body,
-    mocker
-):
-    """
-    Test to verify the correct task status when it's
-    waiting or Running on k8s. Output would be similar
-    """
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-
-    mocker.patch(
-        'app.models.task.Task.get_current_pod',
-        return_value=Mock(
-            status=Mock(
-                container_statuses=[running_state]
-            )
-        )
-    )
-
-    response_id = client.get(
-        f'/tasks/{response.json["task_id"]}',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response_id.status_code == 200
-    assert response_id.json["status"] == {'running': {'started_at': '1/1/2024'}}
-
-    mocker.patch(
-        'app.models.task.Task.get_current_pod',
-        return_value=Mock(
-            status=Mock(
-                container_statuses=[waiting_state]
-            )
-        )
-    )
-
-    response_id = client.get(
-        f'/tasks/{response.json["task_id"]}',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response_id.status_code == 200
-    assert response_id.json["status"] == {'waiting': {'started_at': '1/1/2024'}}
-
-def test_get_task_status_terminated(
-    cr_client,
-    registry_client,
-    terminated_state,
-    post_json_admin_header,
-    client,
-    task_body,
-    mocker
-):
-    """
-    Test to verify the correct task status when it's terminated on k8s
-    """
-    response = client.post(
-        '/tasks/',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response.status_code == 201
-
-    mocker.patch(
-        'app.models.task.Task.get_current_pod',
-        return_value=Mock(
-            status=Mock(
-                container_statuses=[terminated_state]
-            )
-        )
-    )
-
-    response_id = client.get(
-        f'/tasks/{response.json["task_id"]}',
-        data=json.dumps(task_body),
-        headers=post_json_admin_header
-    )
-    assert response_id.status_code == 200
-    expected_status = {
-        'terminated': {
-            'started_at': '1/1/2024',
-            'finished_at': '1/1/2024',
-            'reason': 'Completed successfully!',
-            'exit_code': 0
-        }
-    }
-    assert response_id.json["status"] == expected_status
 
 class TestResourceValidators:
     def test_valid_values(
             self,
             mocker,
+            mocks_kc_tasks,
             user_uuid,
             registry_client,
             cr_client,
@@ -713,15 +672,12 @@ class TestResourceValidators:
                 "memory": "100Mi"
             }
         }
-        mocker.patch("app.helpers.keycloak.Keycloak.get_token_from_headers",
-                     return_value="")
-        mocker.patch("app.helpers.keycloak.Keycloak.decode_token",
-                     return_value={"sub": user_uuid})
         Task.validate(task_body)
 
     def test_invalid_memory_values(
             self,
             mocker,
+            mocks_kc_tasks,
             user_uuid,
             cr_client,
             registry_client,
@@ -730,11 +686,6 @@ class TestResourceValidators:
         """
         Tests that the unexpected memory values are not accepted
         """
-        mocker.patch("app.helpers.keycloak.Keycloak.get_token_from_headers",
-                     return_value="")
-        mocker.patch("app.helpers.keycloak.Keycloak.decode_token",
-                     return_value={"sub": user_uuid})
-
         invalid_values = ["hundredMi", "100ki", "100mi", "0.1Ki", "Mi100"]
         for in_val in invalid_values:
             task_body["resources"] = {
@@ -754,6 +705,7 @@ class TestResourceValidators:
     def test_invalid_cpu_values(
             self,
             mocker,
+            mocks_kc_tasks,
             user_uuid,
             cr_client,
             registry_client,
@@ -762,11 +714,6 @@ class TestResourceValidators:
         """
         Tests that the unexpected cpu values are not accepted
         """
-        mocker.patch("app.helpers.keycloak.Keycloak.get_token_from_headers",
-                     return_value="")
-        mocker.patch("app.helpers.keycloak.Keycloak.decode_token",
-                     return_value={"sub": user_uuid})
-
         invalid_values = ["5.24.1", "hundredm", "100Ki", "100mi", "0.1m"]
 
         for in_val in invalid_values:
@@ -787,6 +734,7 @@ class TestResourceValidators:
     def test_mem_limit_lower_than_request_fails(
             self,
             mocker,
+            mocks_kc_tasks,
             user_uuid,
             cr_client,
             registry_client,
@@ -795,11 +743,6 @@ class TestResourceValidators:
         """
         Tests that the unexpected cpu values are not accepted
         """
-        mocker.patch("app.helpers.keycloak.Keycloak.get_token_from_headers",
-                     return_value="")
-        mocker.patch("app.helpers.keycloak.Keycloak.decode_token",
-                     return_value={"sub": user_uuid})
-
         task_body["resources"] = {
             "limits": {
                 "cpu": "100m",
@@ -817,6 +760,7 @@ class TestResourceValidators:
     def test_cpu_limit_lower_than_request_fails(
             self,
             mocker,
+            mocks_kc_tasks,
             user_uuid,
             cr_client,
             registry_client,
@@ -825,11 +769,6 @@ class TestResourceValidators:
         """
         Tests that the unexpected cpu values are not accepted
         """
-        mocker.patch("app.helpers.keycloak.Keycloak.get_token_from_headers",
-                     return_value="")
-        mocker.patch("app.helpers.keycloak.Keycloak.decode_token",
-                     return_value={"sub": user_uuid})
-
         task_body["resources"] = {
             "limits": {
                 "cpu": "100m",

--- a/webserver/tests/test_token_transfer.py
+++ b/webserver/tests/test_token_transfer.py
@@ -1,5 +1,7 @@
+from datetime import datetime, timedelta
 import json
 from unittest import mock
+from app.models.request import Request
 
 
 class TestTransfers:
@@ -74,30 +76,79 @@ class TestTransfers:
         )
         assert response.status_code == 403
 
-    def test_workspace_token_transfer_admin(
+    def test_transfer_does_not_override_existing(
             self,
             client,
-            simple_admin_header
-    ):
+            post_json_admin_header,
+            access_request,
+            approve_request,
+            request_model_body,
+            request_base_body,
+            dataset
+        ):
         """
-        Test token transfer is not accessible by non-admin users
+        Tests that a duplicate, or a time-overlapping request
+        is not accepted.
         """
-        response = client.post(
-            "/datasets/workspace/token",
-            headers=simple_admin_header
-        )
-        assert response.status_code == 200
+        Request(**request_model_body).add()
+        request_base_body["proj_end"] = (
+            datetime.strptime(request_base_body["proj_end"], "%Y-%m-%d") + timedelta(days=20)
+        ).strftime("%Y-%m-%d")
 
-    def test_workspace_token_transfer_standard_user(
+        response = client.post(
+            "/datasets/token_transfer",
+            headers=post_json_admin_header,
+            data=json.dumps(request_base_body)
+        )
+        assert response.status_code == 400
+
+    def test_transfer_successful_same_name_ds_different_time(
             self,
             client,
-            simple_user_header
-    ):
+            post_json_admin_header,
+            access_request,
+            approve_request,
+            request_model_body,
+            request_base_body,
+            dataset
+        ):
         """
-        Test workspace token transfer is not accessible by non-admin users
+        Tests that a duplicate, not time-overlapping request
+        is accepted with same ds and project name.
         """
+        request_model_body["proj_end"] = datetime.now().date().strftime("%Y-%m-%d")
+        Request(**request_model_body).add()
+        request_base_body["proj_start"] = (
+            datetime.strptime(request_base_body["proj_end"], "%Y-%m-%d") + timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+
         response = client.post(
-            "/datasets/workspace/token",
-            headers=simple_user_header
+            "/datasets/token_transfer",
+            headers=post_json_admin_header,
+            data=json.dumps(request_base_body)
         )
-        assert response.status_code == 403
+        assert response.status_code == 201
+
+    def test_transfer_only_one_ds_per_project(
+            self,
+            client,
+            post_json_admin_header,
+            access_request,
+            approve_request,
+            request_model_body,
+            request_base_body,
+            dataset,
+            dataset2
+        ):
+        """
+        Tests that only one dataset per active project is allowed.
+        """
+        Request(**request_model_body).add()
+        request_base_body["dataset_id"] = dataset2.id
+
+        response = client.post(
+            "/datasets/token_transfer",
+            headers=post_json_admin_header,
+            data=json.dumps(request_base_body)
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
- The datasets are now strictly linked to the `token_transfer` request body. A non-admin user can only trigger a task by providing the project-name they have been approved for. This will avoid inconsistencies with names and ids.