### PR TITLE
133 delete endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Releases Changelog
 
+## 1.1.0
+- Added two `DELETE` enpoints for datasets and registries. Using them will remove related k8s secrets, and DB entries. In the case of datasets, dictionaries and catalogues. For registries, all related containers added either manually of via sync (manual or scheduled).
+
 ## 0.12.0
 - Added the Federated Node Task Controller as a chart dependency. This can be installed by setting `outboundMode` to true on the values file. By default, it won't be installed.
 - Some jobs will be cleaned before and after an upgrade.

--- a/webserver/app/helpers/wrappers.py
+++ b/webserver/app/helpers/wrappers.py
@@ -109,21 +109,6 @@ def audit(func):
         return response_object, http_status
     return _audit
 
-def find_and_delete_key(obj: dict, key: str):
-    """
-    Given a dictionary, tries to find a (nested) key and pops it
-    """
-    copy_obj = obj.copy()
-    for k, v in copy_obj.items():
-        if isinstance(v, dict):
-            find_and_delete_key(v, key)
-        elif isinstance(v, list):
-            for item in obj[k]:
-                if isinstance(item, dict):
-                    find_and_delete_key(item, key)
-        elif k == key:
-            obj.pop(key, None)
-
 def find_and_redact_key(obj: dict, key: str):
     """
     Given a dictionary, tries to find a (nested) key and redact its value

--- a/webserver/app/registries_api.py
+++ b/webserver/app/registries_api.py
@@ -39,6 +39,21 @@ def registry_by_id(registry_id:int):
     return registry.sanitized_dict(), 200
 
 
+@bp.route('/<int:registry_id>', methods=['DELETE'])
+@audit
+@auth(scope='can_admin_dataset')
+def delete_registry_by_id(registry_id:int):
+    """
+    GET /registries endpoint.
+    """
+    registry = Registry.query.filter_by(id=registry_id).one_or_none()
+    if registry is None:
+        raise DBRecordNotFoundError("Registry not found")
+
+    registry.delete(commit=True)
+    return "", 204
+
+
 @bp.route('/', methods=['POST'])
 @bp.route('', methods=['POST'])
 @audit

--- a/webserver/app/static/openapi.json
+++ b/webserver/app/static/openapi.json
@@ -180,6 +180,39 @@
             "$ref": "#/components/responses/InternalError"
           }
         }
+      },
+      "delete":{
+        "operationId": "deleteDataset",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema":{"type": "integer"},
+            "required": true
+          }
+        ],
+        "tags": ["Datasets"],
+        "summary": "Deletes a dataset mapping with its kubernetes secrets.",
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400":{
+            "$ref": "#/components/responses/InvalidBody"
+          },
+          "401":{
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403":{
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404":{
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500":{
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
       }
     },
     "/datasets/{id}/catalogue": {
@@ -297,6 +330,81 @@
         "responses": {
           "200":{
             "$ref": "#/components/responses/DatasetById"
+          },
+          "401":{
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403":{
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404":{
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500":{
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "editDataset",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema":{"type": "integer"},
+            "required": true
+          }
+        ],
+        "tags": ["Datasets"],
+        "summary": "Edit a dataset information. Any of the fields provided on the POST or returned by the GET on this same endpoint, is a valid body",
+        "requestBody": {
+          "content": {
+            "application/json":{
+              "schema":{
+                "$ref": "#/components/schemas/DatasetPostBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400":{
+            "$ref": "#/components/responses/InvalidBody"
+          },
+          "401":{
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403":{
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404":{
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500":{
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteDataset",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema":{"type": "integer"},
+            "required": true
+          }
+        ],
+        "tags": ["Datasets"],
+        "summary": "Deletes a dataset mapping with its kubernetes secrets.",
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/DatasetPost"
+          },
+          "400":{
+            "$ref": "#/components/responses/InvalidBody"
           },
           "401":{
             "$ref": "#/components/responses/Unauthenticated"
@@ -1046,6 +1154,28 @@
           }
         }
       },
+      "delete": {
+        "operationId": "deleteRegisries",
+        "tags": ["Registries"],
+        "summary": "List all container registries available",
+        "responses": {
+          "204":{
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400":{
+            "$ref": "#/components/responses/InvalidBody"
+          },
+          "401":{
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403":{
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500":{
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
       "post":{
         "operationId": "postRegistries",
         "tags": ["Registries"],
@@ -1358,6 +1488,9 @@
             "example": "Ok"
           }
         }
+      },
+      "NoContent": {
+        "description": "No content response"
       },
       "AuditList": {
         "description": "List of actions performed against the webserver",

--- a/webserver/tests/conftest.py
+++ b/webserver/tests/conftest.py
@@ -1,7 +1,7 @@
 import base64
 import copy
-import json
 import os
+from typing import List
 import pytest
 import requests
 from uuid import uuid4
@@ -13,6 +13,8 @@ from unittest.mock import Mock
 from app import create_app
 from app.helpers.base_model import db
 from app.models.dataset import Dataset
+from app.models.catalogue import Catalogue
+from app.models.dictionary import Dictionary
 from app.models.request import Request
 from app.models.task import Task
 from app.helpers.keycloak import Keycloak, URLS, KEYCLOAK_SECRET, KEYCLOAK_CLIENT
@@ -244,18 +246,32 @@ def dataset_post_body():
     return copy.deepcopy(sample_ds_body)
 
 @pytest.fixture
-def dataset(mocker, client, user_uuid, k8s_client):
+def dataset(mocker, client, user_uuid, k8s_client) -> Dataset:
     mocker.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=True)
     dataset = Dataset(name="TestDs", host="example.com", password='pass', username='user')
     dataset.add(user_id=user_uuid)
     return dataset
 
 @pytest.fixture
-def dataset2(mocker, client, user_uuid, k8s_client):
+def dataset2(mocker, client, user_uuid, k8s_client) -> Dataset:
     mocker.patch('app.helpers.wrappers.Keycloak.is_token_valid', return_value=True)
     dataset = Dataset(name="AnotherDS", host="example.com", password='pass', username='user')
     dataset.add(user_id=user_uuid)
     return dataset
+
+@pytest.fixture
+def catalogue(dataset) -> Catalogue:
+    cat = Catalogue(dataset=dataset, title="new catalogue", description="shiny fresh data")
+    cat.add()
+    return cat
+
+@pytest.fixture
+def dictionary(dataset) -> List[Dictionary]:
+    cat1 = Dictionary(dataset=dataset, description="Patient id", table_name="patients", field_name="id", label="p_id")
+    cat2 = Dictionary(dataset=dataset, description="Patient info", table_name="patients", field_name="name", label="p_name")
+    cat1.add()
+    cat2.add()
+    return [cat1, cat2]
 
 @pytest.fixture
 def task(basic_user, image_name, dataset) -> Task:

--- a/webserver/tests/test_admin.py
+++ b/webserver/tests/test_admin.py
@@ -90,7 +90,7 @@ class TestAudits:
         data["dictionaries"][0]["password"] = "2ecr3t!"
         resp = client.post(
             '/datasets/',
-            data=json.dumps(data),
+            json=data,
             headers=post_json_admin_header
         )
 

--- a/webserver/tests/test_datasets.py
+++ b/webserver/tests/test_datasets.py
@@ -972,3 +972,86 @@ class TestBeacon:
         )
         assert response.status_code == 500
         assert response.json['error'] == 'Could not connect to the database'
+
+
+class TestDeleteDataset(MixinTestDataset):
+    def test_delete_dataset_with_secrets(
+            self,
+            client,
+            dataset,
+            post_json_admin_header,
+            k8s_client
+    ):
+        """
+        Test to make sure the db entry and k8s secret are deleted
+        """
+        ds_id = dataset.id
+        secret_name = dataset.get_creds_secret_name()
+        response = client.delete(
+            f"/datasets/{ds_id}",
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 204
+        k8s_client["delete_namespaced_secret_mock"].assert_called_with(
+            secret_name, 'default'
+        )
+
+    def test_delete_dataset_not_found(
+            self,
+            client,
+            dataset,
+            post_json_admin_header,
+            k8s_client
+    ):
+        """
+        Deleting a non existing dataset, returns a 404
+        """
+        ds_id = dataset.id + 1
+        response = client.delete(
+            f"/datasets/{ds_id}",
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 404
+        k8s_client["delete_namespaced_secret_mock"].assert_not_called()
+
+    @mock.patch('app.datasets_api.Dataset.delete', side_effect=Exception())
+    def test_delete_dataset_with_secrets_error(
+            self,
+            delete_mock,
+            client,
+            dataset,
+            post_json_admin_header,
+            k8s_client
+    ):
+        """
+        Test to make sure the db entry and k8s secret are
+        not deleted if an exception is raised
+        """
+        ds_id = dataset.id
+        response = client.delete(
+            f"/datasets/{ds_id}",
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 400
+        assert Dataset.query.filter_by(id=ds_id).one_or_none()
+        k8s_client["delete_namespaced_secret_mock"].assert_not_called()
+
+    def test_delete_dataset_with_catalougues(
+            self,
+            client,
+            dataset,
+            post_json_admin_header,
+            catalogue,
+            dictionary
+    ):
+        """
+        Test to make sure the cascade deletion happens
+        """
+        ds_id = dataset.id
+        response = client.delete(
+            f"/datasets/{ds_id}",
+            headers=post_json_admin_header
+        )
+        assert response.status_code == 204
+        assert Catalogue.query.filter_by(dataset_id=ds_id).count() == 0
+        assert Dictionary.query.filter_by(dataset_id=ds_id).count() == 0

--- a/webserver/tests/test_registries.py
+++ b/webserver/tests/test_registries.py
@@ -1,3 +1,8 @@
+import json
+from kubernetes.client import ApiException
+
+from app.helpers.const import TASK_NAMESPACE, DEFAULT_NAMESPACE
+from app.helpers.kubernetes import KubernetesClient
 from tests.fixtures.azure_cr_fixtures import *
 
 
@@ -217,3 +222,70 @@ class TestRegistriesApi:
         assert resp.status_code == 400
         assert resp.json["error"] == f"Registry {registry.url} already exist"
         assert Registry.query.filter_by(url=registry.url).count() == 1
+
+class TestDeleteRegistries:
+    def test_delete_registry(
+            self,
+            client,
+            registry,
+            reg_k8s_client,
+            simple_admin_header
+    ):
+        """
+        Simple test to check a successful deletion from the
+        DB and its k8s secrets
+        """
+        expected_taskspull = KubernetesClient.encode_secret_value(json.dumps({"auths": {}}))
+        secret_name = registry.slugify_name()
+        response = client.delete(
+            f"/registries/{registry.id}",
+            headers=simple_admin_header
+        )
+        assert response.status_code == 204
+        patch_delete = reg_k8s_client["patch_namespaced_secret_mock"].mock_calls[1]
+        assert patch_delete[-1]["name"] == "taskspull"
+        assert patch_delete[-1]["namespace"] == TASK_NAMESPACE
+        assert patch_delete[-1]["body"].data[".dockerconfigjson"] == expected_taskspull
+        reg_k8s_client["delete_namespaced_secret_mock"].assert_called_with(
+            **{"name": secret_name, "namespace": DEFAULT_NAMESPACE}
+        )
+
+    def test_delete_registry_not_found(
+            self,
+            client,
+            registry,
+            reg_k8s_client,
+            simple_admin_header
+    ):
+        """
+        Return a 404 response if a registry cannot be found
+        """
+        response = client.delete(
+            f"/registries/{registry.id + 1}",
+            headers=simple_admin_header
+        )
+        assert response.status_code == 404
+
+    def test_delete_registry_k8s_error(
+            self,
+            client,
+            registry,
+            reg_k8s_client,
+            simple_admin_header
+    ):
+        """
+        Return a 500 stauts code when a k8s exception is raised
+            but the db record is still deleted. This is an intentional
+            behaviour as the sync and container check are based
+            on the db entry. Secrets can stay if k8s fails.
+        """
+        reg_k8s_client["patch_namespaced_secret_mock"].side_effect = ApiException(
+            http_resp=Mock(status=500, reason="Error", data="Invalid value in data")
+        )
+        reg_id = registry.id
+        response = client.delete(
+            f"/registries/{reg_id}",
+            headers=simple_admin_header
+        )
+        assert response.status_code == 500
+        assert Registry.query.filter_by(id=reg_id).one_or_none() is None


### PR DESCRIPTION
- Added two `DELETE` enpoints for datasets and registries. Using them will remove related k8s secrets, and DB entries. In the case of datasets, dictionaries and catalogues will be deleted. For registries, all related containers added either manually of via sync (manual or scheduled).