### PR TITLE
certmanager-config bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.1.0
 - Added a `PATCH` endpoint for `/registries` so it's easier to update credentials
 - Added the `active` field for registries, so outdated ones can be safely deactivated
+- `cert-manager`'s Certificate now supports `rotationPolicy` via the `certs.rotationPolicy` field. Defaults to `Never`. The other value supported is `Always`.
+
+### Bugfixes
+- The secret for the cert manager are now automatically copied to the appropriate namespace.
 
 ## 1.0.0
 - Added the Federated Node Task Controller as a chart dependency. This can be installed by setting `outboundMode` to true on the values file. By default, it won't be installed.

--- a/k8s/federated-node/templates/certificates/certificate.yaml
+++ b/k8s/federated-node/templates/certificates/certificate.yaml
@@ -14,4 +14,6 @@ spec:
   issuerRef:
     name: ssl-issuer
     kind: ClusterIssuer
+  privateKey:
+    rotationPolicy: {{ .Values.certs.rotationPolicy | default "Never" }}
 {{- end }}

--- a/k8s/federated-node/templates/copy-sercets.yaml
+++ b/k8s/federated-node/templates/copy-sercets.yaml
@@ -15,12 +15,26 @@ type: {{ $sec.type }}
 ---
 {{- end }}
 {{- if .Values.storage.azure }}
-{{ $sec := lookup "v1" "Secret" $.Release.Namespace .Values.storage.azure.secretName | default dict }}
+{{ $sec := lookup "v1" "Secret" .Release.Namespace .Values.storage.azure.secretName | default dict }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.storage.azure.secretName }}
   namespace: {{ include "tasks_namespace" . }}
+data:
+{{- with $sec.data  }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+type: {{ $sec.type}}
+---
+{{- end }}
+{{- if and (index .Values "cert-manager" "enabled") (or .Values.on_eks .Values.on_aks) }}
+{{ $sec := lookup "v1" "Secret" .Release.Namespace (.Values.certs.azure.secretName | default .Values.certs.aws) | default dict }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.certs.azure.secretName }}
+  namespace: {{ (index .Values "cert-manager" "namespace") }}
 data:
 {{- with $sec.data  }}
 {{ toYaml . | indent 2 }}

--- a/k8s/federated-node/values.yaml
+++ b/k8s/federated-node/values.yaml
@@ -106,6 +106,7 @@ on_aks: false
 on_eks: false
 
 certs:
+  rotationPolicy: Never
   azure: {}
     # secretName:
     # configmap:


### PR DESCRIPTION
- `cert-manager`'s Certificate now supports `rotationPolicy` via the `certs.rotationPolicy` field. Defaults to `Never`. The other value supported is `Always`.

### Bugfixes
- The secret for the cert manager are now automatically copied to the appropriate namespace.