### PR TITLE
Fully implement NFS storage support for on-prem installations

### DIFF
--- a/k8s/federated-node/templates/backend-configmap.yaml
+++ b/k8s/federated-node/templates/backend-configmap.yaml
@@ -37,6 +37,11 @@ data:
   AZURE_SHARE_NAME: {{ .Values.storage.azure.shareName }}/results
   AZURE_SECRET_NAME: {{ .Values.storage.azure.secretName | default "azure-storage-secret" }}
 {{- end }}
+{{- if .Values.storage.nfs }}
+  NFS_STORAGE_ENABLED: "true"
+  NFS_SERVER: {{ .Values.storage.nfs.url }}
+  NFS_PATH: {{ .Values.storage.nfs.path }}/results
+{{- end }}
 {{- if .Values.taskReview }}
   TASK_REVIEW: enabled
 {{- end }}

--- a/k8s/federated-node/templates/storageclass.yaml
+++ b/k8s/federated-node/templates/storageclass.yaml
@@ -18,7 +18,7 @@ parameters:
   fileSystemId: {{ include "awsStorageAccount" . }}
   directoryPerms: "777"
 {{- else if .Values.storage.nfs }}
-provisioner: {{ .Values.storage.nfs.provisioner }}
+provisioner: {{ .Values.storage.nfs.provisioner | default "kubernetes.io/no-provisioner" }}
 mountOptions:
   - hard
 {{- end }}

--- a/webserver/app/helpers/task_pod.py
+++ b/webserver/app/helpers/task_pod.py
@@ -9,7 +9,7 @@ from kubernetes.client import (
     V1PersistentVolume, V1PersistentVolumeClaim,
     V1EnvVarSource, V1SecretKeySelector,
     V1PersistentVolumeClaimSpec, V1VolumeResourceRequirements,
-    V1CSIPersistentVolumeSource
+    V1CSIPersistentVolumeSource, V1NFSVolumeSource
 )
 from app.helpers.const import ALPINE_IMAGE, RESULTS_PATH, STORAGE_CLASS, TASK_NAMESPACE, MOUNT_OPTIONS
 from app.helpers.kubernetes import KubernetesClient
@@ -117,6 +117,12 @@ class TaskPod:
             pv_spec.csi=V1CSIPersistentVolumeSource(
                 driver=os.getenv("AWS_STORAGE_DRIVER"),
                 volume_handle=os.getenv("AWS_FILES_SYSTEM_ID")
+            )
+        elif os.getenv("NFS_STORAGE_ENABLED"):
+            pv_spec.nfs=V1NFSVolumeSource(
+                server=os.getenv("NFS_SERVER"),
+                path=os.getenv("NFS_PATH"),
+                read_only=False
             )
         else:
             pv_spec.host_path=V1HostPathVolumeSource(


### PR DESCRIPTION
NFS storage was partially implemented but broken at the task execution layer, causing silent data loss. Tasks appeared to complete successfully but results were written to a local hostPath on the node rather than the shared NFS volume, making them unreachable by the result-task-job.