### PR TITLE
Fix: tests are not using UV lock file

### DIFF
--- a/webserver/build/test.Dockerfile
+++ b/webserver/build/test.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.13.5-slim
 
 COPY ./ /app
-COPY ../../pyproject.toml /
+COPY ../../pyproject.toml ../../uv.lock /
 
 ENV PYTHONDONTWRITEBYTECODE=1
 


### PR DESCRIPTION
The tests are not being run using the uv.lock file and are now failing on the main branch due to a breaking changes in `kubernetes`

See https://github.com/Aridhia-Open-Source/PHEMS_federated_node/actions/runs/26211710444