### PR TITLE
Fixes after the pip compile work

### DIFF
--- a/k8s/federated-node/templates/backend-deployment.yaml
+++ b/k8s/federated-node/templates/backend-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: db-migrations
           image: {{ template "backend-image" . }}
           command: ["/bin/sh"]
-          workingDir: /
+          workingDir: /webserver
           {{- include "nonRootSC" . | nindent 10 }}
           args:
             [


### PR DESCRIPTION
Issues with init containers raised by QC

$ kubectl get pods -n qcfederatednode
NAME                                     READY   STATUS                  RESTARTS        AGE
backend-5cc59db4f4-zwjhp                 1/1     Running                 0               4d22h
backend-b45864cb7-5tszm                  0/1     Init:CrashLoopBackOff   6 (3m15s ago)   9m35s