### PR TITLE
Fix: Added auth decorator to the GET /containers endpoint

### DIFF
--- a/webserver/app/containers_api.py
+++ b/webserver/app/containers_api.py
@@ -17,12 +17,11 @@ from .models.container import Container
 from .models.registry import Registry
 from .helpers.const import ENABLE_IMAGE_WHITELIST
 
-
 bp = Blueprint('containers', __name__, url_prefix='/containers')
-
 logger = logging.getLogger('containers_api')
 logger.setLevel(logging.INFO)
 session = db.session
+
 
 @bp.before_request
 def check_validation_enabled():
@@ -33,9 +32,11 @@ def check_validation_enabled():
         return {"error": "Container validation is disabled"}, HTTPStatus.FORBIDDEN
     return None
 
+
 @bp.route('/', methods=['GET'])
 @bp.route('', methods=['GET'])
 @audit
+@auth(scope='can_admin_dataset')
 def get_all_containers():
     """
     GET /containers endpoint.

--- a/webserver/tests/test_containers.py
+++ b/webserver/tests/test_containers.py
@@ -75,17 +75,29 @@ class TestContainers(ContainersMixin):
             with pytest.raises(InvalidRequest):
                 Container.validate(container_body)
 
-    def test_get_all_containers(self, client, container, enable_image_whitelist):
+    def test_get_all_containers(self, client, container, enable_image_whitelist, post_json_admin_header):
         """
         Basic test for returning a correct response body
         on /GET /containers
         """
-        resp = client.get("/containers")
+        resp = client.get("/containers", headers=post_json_admin_header)
         if not enable_image_whitelist:
             assert resp.status_code == HTTPStatus.FORBIDDEN
             return
         assert resp.status_code == HTTPStatus.OK
         assert any(item["id"] == container.id for item in resp.json["items"])
+
+    def test_get_all_containers_non_auth(self, client, container, enable_image_whitelist, simple_user_header, mock_kc_client):
+        """
+        Basic test to make sure only admin users can
+        use the endpoint
+        """
+        mock_kc_client["wrappers_kc"].return_value.is_token_valid.return_value = False
+        resp = client.get(f"/containers", headers=simple_user_header)
+        if not enable_image_whitelist:
+            assert resp.status_code == HTTPStatus.FORBIDDEN  # Gate hook runs first
+            return
+        assert resp.status_code == HTTPStatus.FORBIDDEN  # auth wrapper returns 403
 
     def test_get_image_by_id(self, client, container, enable_image_whitelist, post_json_admin_header):
         """


### PR DESCRIPTION
Fix: Added auth decorator to the GET /containers endpoint and updated the relevant python tests